### PR TITLE
Added interface Actor, rather than using plain function.

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -73,16 +73,21 @@ func main() {
 	g.AddEncoder(NewNumMesgEncoder, "topic1", "topic2", "topic3")
 
 	// Set processing layers.
-	g.Add("add", 2, add, "topic1")
-	g.Add("mul", 2, mul, "topic2")
-	g.Add("readline", 1, readline, "topic3")
+	g.Add("add", 2, NewAdder(), "topic1")
+	g.Add("mul", 2, NewMultiplier(), "topic2")
+	g.Add("readline", 1, NewReader(), "topic3")
 
 	// Start and wait for exit.
 	g.Start()
 	g.Wait()
 }
 
-func add(in <-chan grid.Event) <-chan grid.Event {
+type add struct{}
+
+func NewAdder() grid.Actor { return &add{} }
+
+func (*add) Act(in <-chan grid.Event) <-chan grid.Event {
+
 	out := make(chan grid.Event)
 
 	go func() {
@@ -119,7 +124,12 @@ func add(in <-chan grid.Event) <-chan grid.Event {
 	return out
 }
 
-func mul(in <-chan grid.Event) <-chan grid.Event {
+type mul struct{}
+
+func NewMultiplier() grid.Actor { return &mul{} }
+
+func (*mul) Act(in <-chan grid.Event) <-chan grid.Event {
+
 	out := make(chan grid.Event)
 
 	go func() {
@@ -156,7 +166,11 @@ func mul(in <-chan grid.Event) <-chan grid.Event {
 	return out
 }
 
-func readline(in <-chan grid.Event) <-chan grid.Event {
+type reader struct{}
+
+func NewReader() grid.Actor { return &reader{} }
+
+func (*reader) Act(in <-chan grid.Event) <-chan grid.Event {
 	out := make(chan grid.Event)
 
 	go func() {

--- a/load_test/load.go
+++ b/load_test/load.go
@@ -82,27 +82,27 @@ func main() {
 		g.AddDecoder(NewNumMesgDecoder, "add1", "mulBy2", "divBy2", "sub1", "collector")
 		g.AddEncoder(NewNumMesgEncoder, "add1", "mulBy2", "divBy2", "sub1", "collector")
 
-		err = g.Add("add1", 3, add, "add1")
+		err = g.Add("add1", 3, newAdd(), "add1")
 		if err != nil {
 			log.Fatalf("error: example: %v", err)
 		}
 
-		err = g.Add("mulBy2", 3, mul, "mulBy2")
+		err = g.Add("mulBy2", 3, newMul(), "mulBy2")
 		if err != nil {
 			log.Fatalf("error: example: %v", err)
 		}
 
-		err = g.Add("divBy2", 3, div, "divBy2")
+		err = g.Add("divBy2", 3, newDiv(), "divBy2")
 		if err != nil {
 			log.Fatalf("error: example: %v", err)
 		}
 
-		err = g.Add("sub1", 3, sub, "sub1")
+		err = g.Add("sub1", 3, newSub(), "sub1")
 		if err != nil {
 			log.Fatalf("error: example: %v", err)
 		}
 
-		err = g.Add("collector", 1, collector, "collector")
+		err = g.Add("collector", 1, newCollector(), "collector")
 		if err != nil {
 			log.Fatalf("error: example: %v", err)
 		}
@@ -168,7 +168,13 @@ func generateTestMessages() {
 	}
 }
 
-func add(in <-chan grid.Event) <-chan grid.Event {
+type add struct{}
+
+func newAdd() grid.Actor {
+	return &add{}
+}
+
+func (*add) Act(in <-chan grid.Event) <-chan grid.Event {
 	fmt.Println("add started.")
 	out := make(chan grid.Event)
 	go func() {
@@ -190,7 +196,13 @@ func add(in <-chan grid.Event) <-chan grid.Event {
 	return out
 }
 
-func mul(in <-chan grid.Event) <-chan grid.Event {
+type mul struct{}
+
+func newMul() grid.Actor {
+	return &mul{}
+}
+
+func (*mul) Act(in <-chan grid.Event) <-chan grid.Event {
 	fmt.Println("mul started.")
 	out := make(chan grid.Event)
 	go func() {
@@ -212,7 +224,13 @@ func mul(in <-chan grid.Event) <-chan grid.Event {
 	return out
 }
 
-func div(in <-chan grid.Event) <-chan grid.Event {
+type div struct{}
+
+func newDiv() grid.Actor {
+	return &div{}
+}
+
+func (*div) Act(in <-chan grid.Event) <-chan grid.Event {
 	fmt.Println("div started.")
 	out := make(chan grid.Event)
 	go func() {
@@ -234,7 +252,13 @@ func div(in <-chan grid.Event) <-chan grid.Event {
 	return out
 }
 
-func sub(in <-chan grid.Event) <-chan grid.Event {
+type sub struct{}
+
+func newSub() grid.Actor {
+	return &sub{}
+}
+
+func (*sub) Act(in <-chan grid.Event) <-chan grid.Event {
 	fmt.Println("sub started.")
 	out := make(chan grid.Event)
 
@@ -257,7 +281,13 @@ func sub(in <-chan grid.Event) <-chan grid.Event {
 	return out
 }
 
-func collector(in <-chan grid.Event) <-chan grid.Event {
+type collector struct{}
+
+func newCollector() grid.Actor {
+	return &collector{}
+}
+
+func (*collector) Act(in <-chan grid.Event) <-chan grid.Event {
 	fmt.Println("collector started.")
 	out := make(chan grid.Event)
 

--- a/manager.go
+++ b/manager.go
@@ -77,7 +77,7 @@ func (m *Manager) stateMachine(in <-chan Event, out chan<- Event) {
 					// we only ever emit once because of the guard.
 					stateclosed = true
 					m.state.Version++
-					m.state.Sched = peersched(m.state.Peers, m.ops, m.parts)
+					m.state.Sched = peersched(m.state.Peers, m.lines, m.parts)
 					log.Printf("grid: manager %v: emitting start state v%d", m.name, m.state.Version)
 					m.state.Epoch = epochid(peerids(m.state)) //The peerstate case below will set m.epoch using this value
 					out <- NewWritable(m.cmdtopic, Key, newPeerStateCmdMsg(m.epoch, m.state.Copy()))

--- a/sched.go
+++ b/sched.go
@@ -1,7 +1,7 @@
 package grid
 
 // peersched creates the schedule of which function instance should run on which peer.
-func peersched(peers map[string]*Peer, ops map[string]*op, parts map[string][]int32) PeerSched {
+func peersched(peers map[string]*Peer, lines map[string]*line, parts map[string][]int32) PeerSched {
 
 	sched := PeerSched{}
 
@@ -12,17 +12,17 @@ func peersched(peers map[string]*Peer, ops map[string]*op, parts map[string][]in
 		sched[peer] = make([]*Instance, 0)
 	}
 
-	for fname, op := range ops {
+	for name, line := range lines {
 
 		// Every function will have N instances of it running
 		// somewhere on the grid. Also, each instance can
 		// read from multiple topics, but only from a sub
 		// set of the partitions.
 
-		finsts := make([]*Instance, op.n)
-		for i := 0; i < op.n; i++ {
-			finsts[i] = NewInstance(i, fname)
-			for topic, _ := range op.inputs {
+		finsts := make([]*Instance, line.n)
+		for i := 0; i < line.n; i++ {
+			finsts[i] = NewInstance(i, name)
+			for topic, _ := range line.inputs {
 				// For every instance create its "topic slice" for
 				// each topic it reads from. A "topic slice" is
 				// just a topic name and a slice partition numbers.
@@ -34,12 +34,12 @@ func peersched(peers map[string]*Peer, ops map[string]*op, parts map[string][]in
 		// remaining partitions of that topic. This basically round-
 		// robins the partitions of a topic to the instance of
 		// functions.
-		for topic, _ := range op.inputs {
+		for topic, _ := range line.inputs {
 			tparts := make([]int32, len(parts[topic]))
 			copy(tparts, parts[topic])
 
 			for i := 0; i < len(tparts); i++ {
-				finsts[i%op.n].TopicSlices[topic] = append(finsts[i%op.n].TopicSlices[topic], tparts[i])
+				finsts[i%line.n].TopicSlices[topic] = append(finsts[i%line.n].TopicSlices[topic], tparts[i])
 			}
 		}
 

--- a/sched_test.go
+++ b/sched_test.go
@@ -17,11 +17,11 @@ func TestPeerSched(t *testing.T) {
 	topics["topic1"] = true
 	topics["topic2"] = true
 
-	ops := make(map[string]*op)
-	op1 := &op{n: 11, inputs: topics}
-	ops["f1"] = op1
-	op2 := &op{n: 7, inputs: topics}
-	ops["f2"] = op2
+	lines := make(map[string]*line)
+	line1 := &line{n: 11, inputs: topics}
+	lines["f1"] = line1
+	line2 := &line{n: 7, inputs: topics}
+	lines["f2"] = line2
 
 	peers := make(map[string]*Peer)
 	peers["host1-123-0"] = newPeer("host1-123-0", time.Now().Unix())
@@ -32,7 +32,7 @@ func TestPeerSched(t *testing.T) {
 	// 'topic1' and 'topic2' are consumed in full, ie: that all their
 	// partitions are being read by one instance of 'f1' or another.
 	// The same expectation holds for instances of 'f2'.
-	sched := peersched(peers, ops, kafkaparts)
+	sched := peersched(peers, lines, kafkaparts)
 
 	// This deep map structure reflects the full list of partitions
 	// that are expected to exist under each function/topic pair.


### PR DESCRIPTION
Once getting to actually trying to use `IdMultiSelect` with Grid, the need for each function instance needing its own state came up immediately.

This PR adds an interface `Actor { Act(in <-chan Event) <-chan Event }` which replaces the `func (in <-chan Event) <-chan Event` that was previously used. I don't know if I like the name `Actor`, because I was hoping for something non-anthropomorphic, but for the time being that's how it ended up.
