### PR TITLE
Makes the state topic readable on its own channel.

### DIFF
--- a/grid.go
+++ b/grid.go
@@ -229,64 +229,26 @@ func (g *Grid) startinst(inst *Instance) {
 		}
 	}
 
-	// The in channel will be used by this instance to receive data, ie: its input.
-	in := make(chan Event)
+	// The in and state channel will be used by this instance to receive data, ie: its input.
+	var in chan Event
+	var state chan Event
 
 	// The out channel will be used by this instance to transmit data, ie: its output.
 	var out <-chan Event
 
-	// Recover previous state if the grid sepcifies a state topic.
-	if parts, found := inst.TopicSlices[g.statetopic]; found {
+	if _, found := inst.TopicSlices[g.statetopic]; found {
 		// Pass both the in and state channels to the actor.
-		state := make(chan Event)
-		out = g.actorconfs[fname].af(fname, id).Act(in, state)
-
-		// Here we get the min and max offset of the state topic.
-		// This is used below to determin if there is anything
-		// in the topic.
-		maxs := make([]int64, len(parts))
-		mins := make([]int64, len(parts))
-		for _, part := range parts {
-			min, max, err := g.log.Offsets(g.statetopic, part)
-			if err != nil {
-				log.Fatalf("fatal: grid: %v: instance: %v: topic: %v: part: %v: failed to get offset: %v", fname, id, g.statetopic, part, err)
-			}
-			maxs[part] = max
-			mins[part] = min
-		}
-
-		// If there is a difference between any partition's
-		// min and max, then we have state events to read.
-		var readstate bool
-		for i, max := range maxs {
-			if mins[i] != max {
-				readstate = true
-				log.Printf("grid: %v: instance: %v: starting state recovery since state messages exist", fname, id)
-			}
-		}
-
-		// If there are state events, use a reader to read them
-		// and pump them into the instance, so it can recover
-		// its state.
-		if readstate {
-			exit := make(chan bool)
-			for event := range g.log.Read(g.statetopic, parts, mins, exit) {
-				if event.Offset()+1 >= maxs[event.Part()] {
-					state <- NewReadable(g.gridname, 0, 0, Ready(true))
-					close(exit)
-				} else {
-					state <- event
-				}
-			}
-		} else {
-			state <- NewReadable(g.gridname, 0, 0, Ready(true))
-			log.Printf("grid: %v: instance: %v: skipping state recovery since no state messages exist", fname, id)
-		}
+		in = make(chan Event)
+		state = make(chan Event)
 	} else {
 		// Pass only the in channel to the actor, since no state topic was requested.
-		out = g.actorconfs[fname].af(fname, id).Act(in)
+		in = make(chan Event)
 	}
 
+	// Start the actor.
+	out = g.actorconfs[fname].af(fname, id).Act(in, state)
+
+	// Calculate how many partitions need offset information.
 	cnt := 0
 	useoffsets := make(map[string]map[int32]int64)
 
@@ -310,12 +272,7 @@ func (g *Grid) startinst(inst *Instance) {
 				if err != nil {
 					log.Fatalf("fatal: grid: %v: instance: %v: topic: %v: partition: %v: failed getting offset: %v", fname, id, topic, part, err)
 				}
-
-				if topic == g.statetopic {
-					useoffsets[g.statetopic][part] = min
-				} else {
-					in <- NewReadable(g.gridname, 0, 0, MinMaxOffset{Topic: topic, Part: part, Min: min, Max: max})
-				}
+				in <- NewReadable(g.gridname, 0, 0, MinMaxOffset{Topic: topic, Part: part, Min: min, Max: max})
 			}
 		}
 	}()
@@ -324,17 +281,10 @@ func (g *Grid) startinst(inst *Instance) {
 	// for each min-max topic-partition pair sent to it.
 	go func() {
 		defer wg.Done()
-		ntopics := len(inst.TopicSlices)
 
 		// Check if this is a source.
-		if 0 == ntopics {
+		if 0 == len(inst.TopicSlices) {
 			log.Printf("grid: %v: instance: %v: is a source and has no input topics", fname, id)
-			return
-		}
-
-		// Check if this instance only reads the state topic,
-		// we always use the min offset, so don't ask.
-		if _, usesstate := inst.TopicSlices[g.statetopic]; 1 == ntopics && usesstate {
 			return
 		}
 
@@ -357,21 +307,30 @@ func (g *Grid) startinst(inst *Instance) {
 	// Start the true topic reading. The messages on the input channels are
 	// mux'ed and put onto a single merged input channel.
 	for topic, parts := range inst.TopicSlices {
-		go func() {
-			offsets := make([]int64, len(parts))
-			for i, part := range parts {
-				if offset, found := useoffsets[topic][part]; !found {
-					log.Fatalf("fatal: grid: %v: instance: %v: failed to find offset for topic: %v: partition: %v", fname, id, topic, part)
-				} else {
-					offsets[i] = offset
-				}
+		offsets := make([]int64, len(parts))
+		for i, part := range parts {
+			if offset, found := useoffsets[topic][part]; !found {
+				log.Fatalf("fatal: grid: %v: instance: %v: failed to find offset for topic: %v: partition: %v", fname, id, topic, part)
+			} else {
+				offsets[i] = offset
 			}
+		}
 
-			log.Printf("grid: starting: %v: instance: %v: topic: %v: partitions: %v: offsets: %v", fname, id, topic, parts, offsets)
-			for event := range g.log.Read(topic, parts, offsets, g.exit) {
-				in <- event
-			}
-		}()
+		log.Printf("grid: starting reader for: %v: instance: %v: topic: %v: partitions: %v: offsets: %v", fname, id, topic, parts, offsets)
+
+		if topic == g.statetopic {
+			go func(topic string, parts []int32, offsets []int64) {
+				for event := range g.log.Read(topic, parts, offsets, g.exit) {
+					state <- event
+				}
+			}(topic, parts, offsets)
+		} else {
+			go func(topic string, parts []int32, offsets []int64) {
+				for event := range g.log.Read(topic, parts, offsets, g.exit) {
+					in <- event
+				}
+			}(topic, parts, offsets)
+		}
 	}
 
 	// Create a mapping of all output topics defined which the instance

--- a/manager_test.go
+++ b/manager_test.go
@@ -10,7 +10,7 @@ import (
 
 type nilactor struct{}
 
-func (a *nilactor) Act(in <-chan Event, state ...<-chan Event) <-chan Event {
+func (a *nilactor) Act(in <-chan Event, state <-chan Event) <-chan Event {
 	return nil
 }
 

--- a/types.go
+++ b/types.go
@@ -7,11 +7,9 @@ import (
 	"io"
 )
 
-// Actor is a stateful processing element in the grid. The state
-// vararg will always either have zero or one arguments. The
-// vararg is used to make it optional.
+// Actor is a stateful processing element in the grid.
 type Actor interface {
-	Act(in <-chan Event, state ...<-chan Event) <-chan Event
+	Act(in <-chan Event, state <-chan Event) <-chan Event
 }
 
 // NewActor creates a new actor giving it a name and an it.


### PR DESCRIPTION
This simple change allows for full coordination and synchronization to happen between all the actors on the grid. This works because each actor can now stop reading the normal `in` channel, get coordination tasks done on the `state` channel and then switch back to the `in` channel. Before the actor had no way of "pausing" the reading of the non-state messages to get only the state messages; the actor would have needed to throw out or buffer the non-state messages while waiting for the state message.
