### PR TITLE
Don't die if producer tries writing a message that is too large.

### DIFF
--- a/kafka.go
+++ b/kafka.go
@@ -7,6 +7,7 @@ import (
 	"hash/fnv"
 	"io"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -230,7 +231,11 @@ func (kl *kafkalog) Write(topic string, in <-chan Event) {
 					Value: sarama.ByteEncoder(val),
 				}:
 				case err := <-producer.Errors():
-					log.Fatalf("fatal: producer: topic: %v: %v", topic, err.Err)
+					if strings.Contains(err.Error(), "Message was too large") {
+						log.Printf("error: producer: topic: %v: %T :: %v", topic, err.Err, err.Error)
+					} else {
+						log.Fatalf("fatal: producer: topic: %v: %T :: %v", topic, err.Err, err.Error)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
If a message is too large, log an error, but don't die. The limit is there for a reason, just respect it and move on.
