### PR TITLE
support nodeid for multiple nodes/host

### DIFF
--- a/example/firstgrid/main.go
+++ b/example/firstgrid/main.go
@@ -17,7 +17,7 @@ const (
 )
 
 func main() {
-	g := grid.New("firstgrid", []string{"http://localhost:2379"}, []string{"nats://localhost:4222"}, &maker{})
+	g := grid.New("firstgrid", "", []string{"http://localhost:2379"}, []string{"nats://localhost:4222"}, &maker{})
 
 	// Start the grid.
 	exit, err := g.Start()

--- a/example/flowgrid/main.go
+++ b/example/flowgrid/main.go
@@ -59,7 +59,7 @@ func main() {
 		log.Fatalf("error: failed to make actor maker: %v", err)
 	}
 
-	g := grid.New(conf.GridName, etcdservers, natsservers, m)
+	g := grid.New(conf.GridName, hostname, etcdservers, natsservers, m)
 
 	exit, err := g.Start()
 	if err != nil {


### PR DESCRIPTION
Currently when running tests, i get failures due to trying to run multiple "grids" in the same test and getting etcd/test failures on unigue nodeid.   