### PR TITLE
check retry error, not error string

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -195,7 +195,7 @@ func (s *sender) send(receiver string, ms []interface{}) error {
 		if err == nil && ack == nil {
 			return fmt.Errorf("received no ack from: %v", receiver)
 		}
-		if err != nil && err.Error() != "nats: Timeout" {
+		if err != nil && err != nats.ErrTimeout {
 			return err
 		}
 		select {


### PR DESCRIPTION
fixes the discrepancy between 
https://github.com/lytics/grid/blob/master/conn.go#L198 and 
https://github.com/nats-io/nats/blob/master/nats.go#L57
