### PR TITLE
Normalize namespace use

### DIFF
--- a/grid.v3/client.go
+++ b/grid.v3/client.go
@@ -73,7 +73,16 @@ func (c *Client) PeersC(ctx context.Context) ([]string, error) {
 
 	peers := make([]string, 0)
 	for _, reg := range regs {
-		peers = append(peers, reg.Key[len(c.namespace+"-"):])
+		prefix := c.namespace + "-"
+		// INVARIANT CHECK
+		// Under all circumstances if a registration is returned
+		// from the prefix scan above, ie: FindRegistrations,
+		// then each registration must contain the namespace
+		// as a prefix with the key.
+		if len(reg.Key) <= len(prefix) {
+			panic("registry key without proper namespace prefix")
+		}
+		peers = append(peers, reg.Key[len(prefix):])
 	}
 
 	return peers, nil

--- a/grid.v3/examples/hello/main.go
+++ b/grid.v3/examples/hello/main.go
@@ -117,7 +117,7 @@ func main() {
 	successOrDie(err)
 }
 
-func successOrDie(err error, loc ...string) {
+func successOrDie(err error) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/grid.v3/examples/hello/main.go
+++ b/grid.v3/examples/hello/main.go
@@ -21,7 +21,7 @@ type LeaderActor struct{}
 
 func (a *LeaderActor) Act(c context.Context) {
 	client, err := grid.ContextClient(c)
-	successOrDie(err, "client")
+	successOrDie(err)
 
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
@@ -34,7 +34,7 @@ func (a *LeaderActor) Act(c context.Context) {
 		case <-ticker.C:
 			// Ask for current peers.
 			peers, err := client.Peers(timeout)
-			successOrDie(err, "peers")
+			successOrDie(err)
 
 			// Check for new peers.
 			for _, peer := range peers {
@@ -50,7 +50,7 @@ func (a *LeaderActor) Act(c context.Context) {
 				// On new peers start the worker.
 				fmt.Println("calling", peer)
 				_, err := client.Request(timeout, peer, def)
-				successOrDie(err, "request")
+				successOrDie(err)
 			}
 		}
 	}
@@ -119,11 +119,7 @@ func main() {
 
 func successOrDie(err error, loc ...string) {
 	if err != nil {
-		if len(loc) == 0 {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		} else {
-			fmt.Fprintf(os.Stderr, "error: %v @ %v\n", err, loc[0])
-		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/grid.v3/examples/hello/main.go
+++ b/grid.v3/examples/hello/main.go
@@ -48,7 +48,6 @@ func (a *LeaderActor) Act(c context.Context) {
 				def.Type = "worker"
 
 				// On new peers start the worker.
-				fmt.Println("calling", peer)
 				_, err := client.Request(timeout, peer, def)
 				successOrDie(err)
 			}

--- a/grid.v3/examples/hello/main.go
+++ b/grid.v3/examples/hello/main.go
@@ -21,7 +21,7 @@ type LeaderActor struct{}
 
 func (a *LeaderActor) Act(c context.Context) {
 	client, err := grid.ContextClient(c)
-	successOrDie(err)
+	successOrDie(err, "client")
 
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
@@ -34,7 +34,7 @@ func (a *LeaderActor) Act(c context.Context) {
 		case <-ticker.C:
 			// Ask for current peers.
 			peers, err := client.Peers(timeout)
-			successOrDie(err)
+			successOrDie(err, "peers")
 
 			// Check for new peers.
 			for _, peer := range peers {
@@ -48,8 +48,9 @@ func (a *LeaderActor) Act(c context.Context) {
 				def.Type = "worker"
 
 				// On new peers start the worker.
+				fmt.Println("calling", peer)
 				_, err := client.Request(timeout, peer, def)
-				successOrDie(err)
+				successOrDie(err, "request")
 			}
 		}
 	}
@@ -116,9 +117,13 @@ func main() {
 	successOrDie(err)
 }
 
-func successOrDie(err error) {
+func successOrDie(err error, loc ...string) {
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		if len(loc) == 0 {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "error: %v @ %v\n", err, loc[0])
+		}
 		os.Exit(1)
 	}
 }

--- a/grid.v3/ring/ring.go
+++ b/grid.v3/ring/ring.go
@@ -150,5 +150,5 @@ func (r *ring) actorDef(i int) *grid.ActorDef {
 }
 
 func (r *ring) actorName(i int) string {
-	return fmt.Sprintf("%s-%s-%d", r.namespace, r.name, i)
+	return fmt.Sprintf("%s-%d", r.name, i)
 }

--- a/grid.v3/ring/ring_test.go
+++ b/grid.v3/ring/ring_test.go
@@ -15,7 +15,7 @@ func TestByInt(t *testing.T) {
 	r := New(namespace, name, 10)
 	for i := int(0); i < 100; i++ {
 		name := r.ByInt(i)
-		if name != fmt.Sprintf("testing-reader-%v", i%10) {
+		if name != fmt.Sprintf("reader-%v", i%10) {
 			t.Fail()
 		}
 	}
@@ -25,7 +25,7 @@ func TestByUint32(t *testing.T) {
 	r := New(namespace, name, 10)
 	for i := uint32(0); i < 100; i++ {
 		name := r.ByUint32(i)
-		if name != fmt.Sprintf("testing-reader-%v", i%10) {
+		if name != fmt.Sprintf("reader-%v", i%10) {
 			t.Fail()
 		}
 	}
@@ -35,7 +35,7 @@ func TestByUint64(t *testing.T) {
 	r := New(namespace, name, 10)
 	for i := uint64(0); i < 100; i++ {
 		name := r.ByUint64(i)
-		if name != fmt.Sprintf("testing-reader-%v", i%10) {
+		if name != fmt.Sprintf("reader-%v", i%10) {
 			t.Fail()
 		}
 	}

--- a/grid.v3/server.go
+++ b/grid.v3/server.go
@@ -114,7 +114,7 @@ func (s *Server) Serve(lis net.Listener) error {
 	s.ctx = ctx
 	s.cancel = cancel
 
-	name := fmt.Sprintf("grid-%v-%v", s.namespace, s.registry.Address)
+	name := fmt.Sprintf("grid-%v", s.registry.Address)
 	name = strings.Replace(name, ":", "-", -1)
 	name = strings.Replace(name, ".", "-", -1)
 	name = strings.Replace(name, "/", "", -1)
@@ -147,6 +147,7 @@ func (s *Server) Serve(lis net.Listener) error {
 			return
 		}
 		def := NewActorDef("leader")
+		def.Namespace = s.namespace
 		for i := 0; i < 6; i++ {
 			time.Sleep(1 * time.Second)
 			err := s.startActor(9*time.Second, def)


### PR DESCRIPTION
The client and server are both localized to a namespace, that's their intention, but you had to pass in receiver names with the namespace already appended.

That seemed redundant and caused some problems with projects using the lib, this PR changes that and now just the name of the actor needs to be passed into `Request` and `RequestC`, the namespace is taken care of by the client itself.