### PR TITLE
Add ability to use mailboxes outside of grid actors.

### DIFF
--- a/grid.v3/README.md
+++ b/grid.v3/README.md
@@ -150,7 +150,7 @@ func (a *WorkerActor) Act(c context.Context) {
     name, err := grid.ContextActorName(c)
 
     // The namespace of the grid this actor is associated with.
-    namespace, err := grid.ContextNamespace(c)
+    namespace, err := grid.ContextActorNamespace(c)
 
     // The etcd client associated with this actor.
     etcd, err := grid.ContextEtcd(c)

--- a/grid.v3/cfg.go
+++ b/grid.v3/cfg.go
@@ -1,8 +1,6 @@
 package grid
 
-import (
-	"time"
-)
+import "time"
 
 // ClientCfg where the only required argument is Namespace,
 // other fields with their zero value will receive defaults.
@@ -11,8 +9,6 @@ type ClientCfg struct {
 	Namespace string
 	// Timeout for communication with etcd, and internal gossip.
 	Timeout time.Duration
-	// LeaseDuration for data in etcd.
-	LeaseDuration time.Duration
 	// PeersRefreshInterval for polling list of peers in etcd.
 	PeersRefreshInterval time.Duration
 }
@@ -24,9 +20,6 @@ func setClientCfgDefaults(cfg *ClientCfg) {
 	}
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 10 * time.Second
-	}
-	if cfg.LeaseDuration == 0 {
-		cfg.LeaseDuration = 60 * time.Second
 	}
 }
 

--- a/grid.v3/cfg_test.go
+++ b/grid.v3/cfg_test.go
@@ -1,0 +1,44 @@
+package grid
+
+import "testing"
+import "time"
+
+func TestSetClientCfgDefaults(t *testing.T) {
+	cfg := ClientCfg{Namespace: "testing"}
+
+	if cfg.Timeout != 0 {
+		t.Fatalf("initial Timeout should be zero value")
+	}
+	if cfg.PeersRefreshInterval != 0 {
+		t.Fatalf("initial PeersRefreshInterval should be zero value")
+	}
+
+	setClientCfgDefaults(&cfg)
+
+	if cfg.Timeout != 10*time.Second {
+		t.Fatalf("initial Timeout should be 10s")
+	}
+	if cfg.PeersRefreshInterval != 2*time.Second {
+		t.Fatalf("initial PeersRefreshInterval should be 2s")
+	}
+}
+
+func TestSetServerCfgDefaults(t *testing.T) {
+	cfg := ServerCfg{Namespace: "testing"}
+
+	if cfg.Timeout != 0 {
+		t.Fatalf("initial Timeout should be zero value")
+	}
+	if cfg.LeaseDuration != 0 {
+		t.Fatalf("initial LeaseDuration should be zero value")
+	}
+
+	setServerCfgDefaults(&cfg)
+
+	if cfg.Timeout != 10*time.Second {
+		t.Fatalf("initial Timeout should be 10s")
+	}
+	if cfg.LeaseDuration != 60*time.Second {
+		t.Fatalf("initial LeaseDuration should be 60s")
+	}
+}

--- a/grid.v3/client.go
+++ b/grid.v3/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
-	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -120,15 +119,10 @@ func (c *Client) Close() error {
 //         }
 //     }
 func (c *Client) PeersWatch(ctx context.Context) ([]string, <-chan *PeerChangeEvent, error) {
-	fmt.Println(">>> calling peers #1")
-
 	peers, err := c.Peers(c.cfg.Timeout)
 	if err != nil {
-		fmt.Println(">>> calling peers #3")
 		return nil, nil, err
 	}
-
-	fmt.Println(">>> finished with peers call")
 
 	currentPeers := map[string]struct{}{}
 	for _, p := range peers {
@@ -181,7 +175,6 @@ func (c *Client) PeersWatch(ctx context.Context) ([]string, <-chan *PeerChangeEv
 // Peers in this client's namespace. A peer is any process that called
 // the Serve method to act as a server for the namespace.
 func (c *Client) Peers(timeout time.Duration) ([]string, error) {
-	fmt.Println(">>>>>>>>> calling peersC #2")
 	timeoutC, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	return c.PeersC(timeoutC)

--- a/grid.v3/client.go
+++ b/grid.v3/client.go
@@ -153,8 +153,8 @@ func (c *Client) PeersWatch(ctx context.Context) ([]string, <-chan *PeerChangeEv
 				for _, p := range peers {
 					currentPeers[p] = struct{}{}
 				}
-				lostPeers := difference(oldPeers, currentPeers)
-				discoveredPeers := difference(currentPeers, oldPeers)
+				lostPeers := minus(oldPeers, currentPeers)
+				discoveredPeers := minus(currentPeers, oldPeers)
 				oldPeers = currentPeers
 
 				for peer := range lostPeers {
@@ -299,16 +299,16 @@ func (c *Client) getWireClient(ctx context.Context, nsReceiver string) (WireClie
 	return cc.client, nil
 }
 
-// difference of sets a and b, in mathematical notation: A \ B,
+// minus of sets a and b, in mathematical notation: A \ B,
 // ie: all elements in A that are not in B.
 //
-// See: https://en.wikipedia.org/wiki/Complement_(set_theory)
+// See: https://www.techonthenet.com/sql/minus.php
 //
 // Example:
 //    lostPeers := difference(oldPeers, currentPeers)
 //    discoveredPeers := difference(currentPeers, oldPeers)
 //
-func difference(a map[string]struct{}, b map[string]struct{}) map[string]struct{} {
+func minus(a map[string]struct{}, b map[string]struct{}) map[string]struct{} {
 	res := map[string]struct{}{}
 	for in := range a {
 		if _, skip := b[in]; !skip {

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -76,8 +76,8 @@ func ContextClient(c context.Context) (*Client, error) {
 	return cv.server.client, nil
 }
 
-// ContextForNonActor useful for creating grid mailboxs in non actors. This
-// use-case occurs when trying to establish bidirectional communication
+// ContextForNonActor is useful for creating grid mailboxs in non actors.
+// This use-case occurs when trying to establish bidirectional communication
 // from a command-line-utility or from some existing service that does
 // not use grid's actors.
 func ContextForNonActor(s *Server) context.Context {

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -30,9 +30,9 @@ func ContextActorName(c context.Context) (string, error) {
 	return cv.actorName, nil
 }
 
-// ContextNamespace returns the namespace of the grid this actor
+// ContextActorNamespace returns the namespace of the grid this actor
 // is associated with.
-func ContextNamespace(c context.Context) (string, error) {
+func ContextActorNamespace(c context.Context) (string, error) {
 	v := c.Value(contextKey)
 	if v == nil {
 		return "", ErrInvalidContext
@@ -42,86 +42,4 @@ func ContextNamespace(c context.Context) (string, error) {
 		return "", ErrInvalidContext
 	}
 	return cv.server.cfg.Namespace, nil
-}
-
-// ContextClient returns the grid client for the grid this actor
-// is associated with.
-func ContextClient(c context.Context) (*Client, error) {
-	v := c.Value(contextKey)
-	if v == nil {
-		return nil, ErrInvalidContext
-	}
-	cv, ok := v.(*contextVal)
-	if !ok {
-		return nil, ErrInvalidContext
-	}
-	return cv.server.client, nil
-}
-
-// ContextForNonActor is useful for creating grid mailboxs in non actors.
-// This use-case occurs when trying to establish bidirectional communication
-// from a command-line-utility or from some existing service that does
-// not use grid's actors.
-//
-// Example usage for a hypothetical cli tool that submits a task and gets
-// the reply back to a mailbox it's listening to.
-//
-//     import (
-//         "github.com/coreos/etcd/clientv3"
-//         "github.com/lytics/grid/grid.v3"
-//     )
-//
-//     etcd, err := clientv3.New(...)
-//     ...
-//
-//     s, err := grid.NewServer(etcd, grid.ServerCfg{Namespace: "cli"}, nil)
-//     ...
-//
-//     lis, err := net.Listener(...)
-//     ...
-//
-//     go func() {
-//         err := s.Serve(lis)
-//         ...
-//     }()
-//
-//     ctx := grid.ContextForNonActor(s)
-//     go func() {
-//         mailbox, err := grid.NewMailbox(ctx, "cli", 1)
-//         ...
-//         defer mailbox.Close()
-//
-//         for {
-//             select {
-//             case <-ctx.Done():
-//                 return
-//             case m := <-mailbox.C:
-//                 // Do something with message.
-//             }
-//         }
-//     }()
-//
-//     c, err := grid.NewClient(etcd, grid.ClientCfg{Namespace: "remote"})
-//     ...
-//
-//     c.Request(timeout, "worker", &StartTask{})
-//     ...
-//
-func ContextForNonActor(s *Server) context.Context {
-	return context.WithValue(s.ctx, contextKey, &contextVal{
-		server: s,
-	})
-}
-
-// contextServer extracts the server from the context.
-func contextServer(c context.Context) (*Server, error) {
-	v := c.Value(contextKey)
-	if v == nil {
-		return nil, ErrInvalidContext
-	}
-	cv, ok := v.(*contextVal)
-	if !ok {
-		return nil, ErrInvalidContext
-	}
-	return cv.server, nil
 }

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -80,6 +80,44 @@ func ContextClient(c context.Context) (*Client, error) {
 // This use-case occurs when trying to establish bidirectional communication
 // from a command-line-utility or from some existing service that does
 // not use grid's actors.
+//
+// Example usage for a hypothetical cli tool that submits a task and gets
+// the reply back to a mailbox it's listening to.
+//
+//     etcd, err := etcdv3.NewClient(...)
+//     ...
+//
+//     s, err := grid.NewServer(etcd, grid.ServerCfg{Namespace: "cli"}, nil)
+//     ...
+//
+//     lis, err := net.Listener(...)
+//     ...
+//
+//     go func() {
+//         err := s.Serve(lis)
+//         ...
+//     }()
+//
+//     ctx := ContextForNonActor(s)
+//     go func() {
+//         mailbox := grid.NewMailbox(ctx, "cli", 1)
+//         defer mailbox.Close()
+//         for {
+//             select {
+//             case <-ctx.Done():
+//                 return
+//             case m := <-mailbox.C:
+//                 // Do something with message.
+//             }
+//         }
+//     }()
+//
+//     c, err := grid.NewClient(etc, grid.ClientCfg{Namespace:"remote"})
+//     ...
+//
+//     c.Request(timeout, "worker", &StartTask{})
+//     ...
+//
 func ContextForNonActor(s *Server) context.Context {
 	return context.WithValue(s.ctx, contextKey, &contextVal{
 		server: s,

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -77,10 +77,9 @@ func ContextClient(c context.Context) (*Client, error) {
 }
 
 // ContextForNonActor useful for creating grid mailboxs in non actors. This
-// use case occurs when trying to establish bidirectional communication
+// use-case occurs when trying to establish bidirectional communication
 // from a command-line-utility or from some existing service that does
-// not use grid's actors interface. The server argument "s" will be
-// listening on the gRPC port.
+// not use grid's actors.
 func ContextForNonActor(s *Server) context.Context {
 	return context.WithValue(s.ctx, contextKey, &contextVal{
 		server: s,

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -117,7 +117,7 @@ func ContextClient(c context.Context) (*Client, error) {
 //         }
 //     }()
 //
-//     c, err := grid.NewClient(etc, grid.ClientCfg{Namespace:"remote"})
+//     c, err := grid.NewClient(etcd, grid.ClientCfg{Namespace: "remote"})
 //     ...
 //
 //     c.Request(timeout, "worker", &StartTask{})

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -85,13 +85,11 @@ func ContextClient(c context.Context) (*Client, error) {
 // the reply back to a mailbox it's listening to.
 //
 //     import (
-//         ...
-//
-//         etcdv3 "github.com/coreos/etcd/clientv3"
+//         "github.com/coreos/etcd/clientv3"
 //         "github.com/lytics/grid/grid.v3"
 //     )
 //
-//     etcd, err := etcdv3.New(...)
+//     etcd, err := clientv3.New(...)
 //     ...
 //
 //     s, err := grid.NewServer(etcd, grid.ServerCfg{Namespace: "cli"}, nil)

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -1,10 +1,6 @@
 package grid
 
-import (
-	"context"
-
-	etcdv3 "github.com/coreos/etcd/clientv3"
-)
+import "context"
 
 // ContextActorID returns an ID that is a concatenation of the context
 // namespace and the actor name associated with this context.
@@ -46,20 +42,6 @@ func ContextNamespace(c context.Context) (string, error) {
 		return "", ErrInvalidContext
 	}
 	return cv.server.cfg.Namespace, nil
-}
-
-// ContextEtcd returns the etcd client for the grid this actor
-// is associated with.
-func ContextEtcd(c context.Context) (*etcdv3.Client, error) {
-	v := c.Value(contextKey)
-	if v == nil {
-		return nil, ErrInvalidContext
-	}
-	cv, ok := v.(*contextVal)
-	if !ok {
-		return nil, ErrInvalidContext
-	}
-	return cv.server.etcd, nil
 }
 
 // ContextClient returns the grid client for the grid this actor
@@ -105,8 +87,10 @@ func ContextClient(c context.Context) (*Client, error) {
 //
 //     ctx := grid.ContextForNonActor(s)
 //     go func() {
-//         mailbox := grid.NewMailbox(ctx, "cli", 1)
+//         mailbox, err := grid.NewMailbox(ctx, "cli", 1)
+//         ...
 //         defer mailbox.Close()
+//
 //         for {
 //             select {
 //             case <-ctx.Done():

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -76,6 +76,17 @@ func ContextClient(c context.Context) (*Client, error) {
 	return cv.server.client, nil
 }
 
+// ContextForNonActor useful for creating grid mailboxs in non actors. This
+// use case occurs when trying to establish bidirectional communication
+// from a command-line-utility or from some existing service that does
+// not use grid's actors interface. The server argument "s" will be
+// listening on the gRPC port.
+func ContextForNonActor(s *Server) context.Context {
+	return context.WithValue(s.ctx, contextKey, &contextVal{
+		server: s,
+	})
+}
+
 // contextServer extracts the server from the context.
 func contextServer(c context.Context) (*Server, error) {
 	v := c.Value(contextKey)

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -43,3 +43,16 @@ func ContextActorNamespace(c context.Context) (string, error) {
 	}
 	return cv.server.cfg.Namespace, nil
 }
+
+// ContextActorServer returns the server associated with this actor.
+func ContextActorServer(c context.Context) (*Server, error) {
+	v := c.Value(contextKey)
+	if v == nil {
+		return nil, ErrInvalidContext
+	}
+	cv, ok := v.(*contextVal)
+	if !ok {
+		return nil, ErrInvalidContext
+	}
+	return cv.server, nil
+}

--- a/grid.v3/context.go
+++ b/grid.v3/context.go
@@ -84,7 +84,14 @@ func ContextClient(c context.Context) (*Client, error) {
 // Example usage for a hypothetical cli tool that submits a task and gets
 // the reply back to a mailbox it's listening to.
 //
-//     etcd, err := etcdv3.NewClient(...)
+//     import (
+//         ...
+//
+//         etcdv3 "github.com/coreos/etcd/clientv3"
+//         "github.com/lytics/grid/grid.v3"
+//     )
+//
+//     etcd, err := etcdv3.New(...)
 //     ...
 //
 //     s, err := grid.NewServer(etcd, grid.ServerCfg{Namespace: "cli"}, nil)
@@ -98,7 +105,7 @@ func ContextClient(c context.Context) (*Client, error) {
 //         ...
 //     }()
 //
-//     ctx := ContextForNonActor(s)
+//     ctx := grid.ContextForNonActor(s)
 //     go func() {
 //         mailbox := grid.NewMailbox(ctx, "cli", 1)
 //         defer mailbox.Close()

--- a/grid.v3/grid_test.go
+++ b/grid.v3/grid_test.go
@@ -14,12 +14,17 @@ import (
 )
 
 func TestServerExample(t *testing.T) {
-	client, cleanup := bootstrap(t)
+	etcd, cleanup := bootstrap(t)
 	defer cleanup()
 	errs := &testerrors{}
 
-	e := &ExampleGrid{errs: errs}
-	g, err := NewServer(client, ServerCfg{Namespace: "example_grid"}, e)
+	client, err := NewClient(etcd, ClientCfg{Namespace: "example_grid"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := &ExampleGrid{errs: errs, client: client}
+	g, err := NewServer(etcd, ServerCfg{Namespace: "example_grid"}, e)
 	if err != nil {
 		t.Fatalf("NewServer failed: %v", err)
 	}

--- a/grid.v3/mailbox.go
+++ b/grid.v3/mailbox.go
@@ -51,17 +51,7 @@ func (box *Mailbox) String() string {
 // started a grid Server. The context agrument must be the same one an
 // actor recieved via its Act method, or a context created using
 // ContextForNonActor.
-func NewMailbox(c context.Context, name string, size int) (*Mailbox, error) {
-	namespace, err := ContextNamespace(c)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := contextServer(c)
-	if err != nil {
-		return nil, err
-	}
-
+func NewMailbox(s *Server, name string, size int) (*Mailbox, error) {
 	if !isServerRunning(s) {
 		return nil, ErrServerNotRunning
 	}
@@ -74,7 +64,7 @@ func NewMailbox(c context.Context, name string, size int) (*Mailbox, error) {
 	defer s.mu.Unlock()
 
 	// Namespaced name.
-	nsName := namespace + "-" + name
+	nsName := s.cfg.Namespace + "-" + name
 
 	_, ok := s.mailboxes[nsName]
 	if ok {
@@ -82,7 +72,7 @@ func NewMailbox(c context.Context, name string, size int) (*Mailbox, error) {
 	}
 
 	timeout, cancel := context.WithTimeout(context.Background(), s.cfg.Timeout)
-	err = s.registry.Register(timeout, nsName)
+	err := s.registry.Register(timeout, nsName)
 	cancel()
 	if err != nil {
 		return nil, err

--- a/grid.v3/mailbox.go
+++ b/grid.v3/mailbox.go
@@ -33,13 +33,6 @@ func NewMailbox(c context.Context, name string, size int) (*Mailbox, error) {
 		return nil, err
 	}
 
-	return NewMailboxWith(s, namespace, name, size)
-}
-
-// NewMailboxWith the server and namespace given explicitly rather than
-// from a context. If creating a new mailbox from within the Act method
-// of an actor, use NewMailbox instead, it's easier.
-func NewMailboxWith(s *Server, namespace, name string, size int) (*Mailbox, error) {
 	if !isServerRunning(s) {
 		return nil, ErrServerNotRunning
 	}
@@ -56,7 +49,7 @@ func NewMailboxWith(s *Server, namespace, name string, size int) (*Mailbox, erro
 	}
 
 	timeout, cancel := context.WithTimeout(context.Background(), s.cfg.Timeout)
-	err := s.registry.Register(timeout, nsName)
+	err = s.registry.Register(timeout, nsName)
 	cancel()
 	if err != nil {
 		return nil, err

--- a/grid.v3/mailbox.go
+++ b/grid.v3/mailbox.go
@@ -48,9 +48,7 @@ func (box *Mailbox) String() string {
 // can claim a particular name.
 //
 // Using a mailbox requires that the process creating the mailbox also
-// started a grid Server. The context agrument must be the same one an
-// actor recieved via its Act method, or a context created using
-// ContextForNonActor.
+// started a grid Server.
 func NewMailbox(s *Server, name string, size int) (*Mailbox, error) {
 	if !isServerRunning(s) {
 		return nil, ErrServerNotRunning

--- a/grid.v3/registry/registry.go
+++ b/grid.v3/registry/registry.go
@@ -64,7 +64,6 @@ func New(client *etcdv3.Client) (*Registry, error) {
 		done:          make(chan bool),
 		exited:        make(chan bool),
 		kv:            etcdv3.NewKV(client),
-		lease:         etcdv3.NewLease(client),
 		leaseID:       -1,
 		client:        client,
 		Timeout:       10 * time.Second,
@@ -80,6 +79,7 @@ func (rr *Registry) Start() (<-chan error, error) {
 	if rr.LeaseDuration < minLeaseDuration {
 		return nil, ErrLeaseDurationTooShort
 	}
+	rr.lease = etcdv3.NewLease(rr.client)
 
 	timeout, cancel := context.WithTimeout(context.Background(), rr.Timeout)
 	res, err := rr.lease.Grant(timeout, int64(rr.LeaseDuration.Seconds()))

--- a/grid.v3/server.go
+++ b/grid.v3/server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -368,7 +369,8 @@ func (s *Server) startActorC(c context.Context, def *ActorDef) error {
 		defer func() {
 			if err := recover(); err != nil {
 				if Logger != nil {
-					log.Printf("panic in actor: %v, recovered from: %v", def.ID(), err)
+					stack := niceStack(debug.Stack())
+					log.Printf("panic in actor: %v, recovered from: %v, stack: %v", def.ID(), err, stack)
 				}
 			}
 		}()

--- a/grid.v3/server.go
+++ b/grid.v3/server.go
@@ -161,10 +161,7 @@ func (s *Server) Serve(lis net.Listener) error {
 		}
 	}()
 	go func() {
-		if s.g == nil {
-			return
-		}
-		if s.cfg.DisalowLeadership {
+		if s.g == nil || s.cfg.DisalowLeadership {
 			return
 		}
 		def := NewActorDef("leader")

--- a/grid.v3/server.go
+++ b/grid.v3/server.go
@@ -379,11 +379,5 @@ func formatAddress(addr net.Addr) (string, error) {
 }
 
 func isServerRunning(s *Server) bool {
-	if s == nil {
-		return false
-	}
-	if s.ctx == nil || s.client == nil || s.cancel == nil || s.registry == nil {
-		return false
-	}
-	return true
+	return !(s == nil || s.ctx == nil || s.client == nil || s.cancel == nil || s.registry == nil)
 }

--- a/grid.v3/server.go
+++ b/grid.v3/server.go
@@ -115,9 +115,8 @@ func (s *Server) Serve(lis net.Listener) error {
 	}
 
 	client, err := NewClient(s.etcd, ClientCfg{
-		Namespace:     s.cfg.Namespace,
-		Timeout:       s.cfg.Timeout,
-		LeaseDuration: s.cfg.LeaseDuration,
+		Namespace: s.cfg.Namespace,
+		Timeout:   s.cfg.Timeout,
 	})
 	if err != nil {
 		return err
@@ -203,10 +202,17 @@ func (s *Server) Stop() {
 		return len(s.mailboxes) == 0
 	}
 
+	t0 := time.Now()
 	for {
 		time.Sleep(200 * time.Millisecond)
 		if zeroMailboxes() {
 			break
+		}
+		if Logger != nil && time.Now().Sub(t0) > 10*time.Second {
+			t0 = time.Now()
+			for _, mailbox := range s.mailboxes {
+				Logger.Printf("%v: waiting for mailbox to close: %v", s.cfg.Namespace, mailbox)
+			}
 		}
 	}
 

--- a/grid.v3/server.go
+++ b/grid.v3/server.go
@@ -137,7 +137,7 @@ func (s *Server) Serve(lis net.Listener) error {
 	name = strings.TrimSpace(name)
 	name = strings.Trim(name, "~\\!@#$%^&*()<>")
 
-	mailbox, err := NewMailbox(s.ctx, name, 10)
+	mailbox, err := NewMailbox(s, name, 10)
 	if err != nil {
 		return err
 	}

--- a/grid.v3/server.go
+++ b/grid.v3/server.go
@@ -63,8 +63,7 @@ type Server struct {
 // in the set: [a-zA-Z0-9-_] and no other.
 //
 // If argument g is nil, then this server will not create actors, will
-// not start a leader, and can be used only for serving incoming
-// messages for mailboxes.
+// not start a leader, and can be used only for serving mailboxes.
 func NewServer(etcd *etcdv3.Client, cfg ServerCfg, g Grid) (*Server, error) {
 	setServerCfgDefaults(&cfg)
 

--- a/grid.v3/server.go
+++ b/grid.v3/server.go
@@ -34,6 +34,7 @@ var (
 	ErrInvalidEtcd             = errors.New("invalid etcd")
 	ErrInvalidContext          = errors.New("invalid context")
 	ErrInvalidNamespace        = errors.New("invalid namespace")
+	ErrServerNotRunning        = errors.New("server not running")
 	ErrAlreadyRegistered       = errors.New("already registered")
 	ErrInvalidMailboxName      = errors.New("invalid mailbox name")
 	ErrUnknownNetAddressType   = errors.New("unknown net address type")
@@ -335,7 +336,7 @@ func (s *Server) startActorC(c context.Context, def *ActorDef) error {
 	}
 
 	// The actor's context contains its full id, it's name and the
-	// full registration, which contains the actors namespace.
+	// full registration, which contains the actor's namespace.
 	actorCtx := context.WithValue(s.ctx, contextKey, &contextVal{
 		server:    s,
 		actorID:   def.ID(),
@@ -353,7 +354,7 @@ func (s *Server) startActorC(c context.Context, def *ActorDef) error {
 		defer func() {
 			if err := recover(); err != nil {
 				if Logger != nil {
-					log.Printf("panic in actor: %v, recovered with: %v", def.ID(), err)
+					log.Printf("panic in actor: %v, recovered from: %v", def.ID(), err)
 				}
 			}
 		}()
@@ -375,4 +376,14 @@ func formatAddress(addr net.Addr) (string, error) {
 		}
 		return fmt.Sprintf("%v:%v", addr.IP, addr.Port), nil
 	}
+}
+
+func isServerRunning(s *Server) bool {
+	if s == nil {
+		return false
+	}
+	if s.ctx == nil || s.client == nil || s.cancel == nil || s.registry == nil {
+		return false
+	}
+	return true
 }

--- a/grid.v3/stack.go
+++ b/grid.v3/stack.go
@@ -1,0 +1,24 @@
+package grid
+
+import "strings"
+import "bytes"
+
+func niceStack(stack []byte) string {
+	lines := strings.Split(string(stack), "\n")
+	var buf bytes.Buffer
+	for i, line := range lines {
+		if strings.Contains(line, ":") {
+			idx := strings.Index(line, "+")
+			if idx > 0 {
+				line = line[:idx-1]
+				line = strings.Replace(line, "\t", "", -1)
+				line = strings.Replace(line, " ", "", -1)
+				buf.WriteString(line)
+				if i < len(lines)-2 {
+					buf.WriteString(" <-- ")
+				}
+			}
+		}
+	}
+	return buf.String()
+}

--- a/grid.v3/stack_test.go
+++ b/grid.v3/stack_test.go
@@ -1,0 +1,27 @@
+package grid
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestNiceStack(t *testing.T) {
+	expected := `/usr/local/go/src/runtime/debug/stack.go:24 <-- /home/mdmarek/src/github.com/lytics/grid/grid.v3/stack_test.go:15 <-- /usr/local/go/src/runtime/panic.go:458 <-- /home/mdmarek/src/github.com/lytics/grid/grid.v3/stack_test.go:18 <-- /home/mdmarek/src/github.com/lytics/grid/grid.v3/stack_test.go:21 <-- /usr/local/go/src/testing/testing.go:610 <-- /usr/local/go/src/testing/testing.go:646`
+
+	var actual string
+	f := func() {
+		defer func() {
+			if err := recover(); err != nil {
+				actual = niceStack(debug.Stack())
+			}
+		}()
+		panic("show stack trace")
+	}
+
+	f()
+	if expected != actual {
+		t.Logf("expected: %v", expected)
+		t.Logf("  actual: %v", actual)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This PR is based on changed from actually trying to use grid in our internal products. The basic changes are: *A mailbox needs a server to run, so have that be its parameter rather than a context*

The rest of the changes are document updates, better logging, and a couple more tests.
