### PR TITLE
More doc around registration object and its use.

### DIFF
--- a/grid.v3/registry/registry.go
+++ b/grid.v3/registry/registry.go
@@ -41,13 +41,14 @@ var (
 
 // Registration information.
 type Registration struct {
-	Key     string `json:"key"`
-	Name    string `json:"name"`
-	Address string `json:"address"`
+	Key      string `json:"key"`
+	Address  string `json:"address"`
+	Registry string `json:"registry"`
 }
 
+// String descritpion of registration.
 func (r *Registration) String() string {
-	return fmt.Sprintf("key: %v, name: %v, address: %v", r.Key, r.Name, r.Address)
+	return fmt.Sprintf("key: %v, address: %v, registry: %v", r.Key, r.Address, r.Registry)
 }
 
 // EventType of a watch event.
@@ -197,8 +198,9 @@ func (rr *Registry) Address() string {
 	return rr.address
 }
 
-// Name of the registry based off the address.
-func (rr *Registry) Name() string {
+// Registry name, which is a human readable all ASCII
+// transformation of the network address.
+func (rr *Registry) Registry() string {
 	return rr.name
 }
 
@@ -391,9 +393,9 @@ func (rr *Registry) Register(c context.Context, key string, options ...Option) e
 	}
 
 	value, err := json.Marshal(&Registration{
-		Key:     key,
-		Name:    rr.name,
-		Address: rr.address,
+		Key:      key,
+		Address:  rr.address,
+		Registry: rr.name,
 	})
 	if err != nil {
 		return err

--- a/grid.v3/registry/registry_test.go
+++ b/grid.v3/registry/registry_test.go
@@ -71,7 +71,7 @@ func TestRegister(t *testing.T) {
 	if reg.Address != r.Address() {
 		t.Fatal("wrong address")
 	}
-	if reg.Name != r.Name() {
+	if reg.Registry != r.Registry() {
 		t.Fatal("wrong name")
 	}
 }
@@ -104,7 +104,7 @@ func TestDeregistration(t *testing.T) {
 	if reg.Address != r.Address() {
 		t.Fatal("wrong address")
 	}
-	if reg.Name != r.Name() {
+	if reg.Registry != r.Registry() {
 		t.Fatal("wrong name")
 	}
 
@@ -416,9 +416,9 @@ func TestWatchEventString(t *testing.T) {
 		Key:  "foo",
 		Type: Create,
 		Reg: &Registration{
-			Key:     "foo",
-			Name:    "goo",
-			Address: "localhost:7777",
+			Key:      "foo",
+			Address:  "localhost:7777",
+			Registry: "goo",
 		},
 	}
 

--- a/grid.v3/server.go
+++ b/grid.v3/server.go
@@ -107,7 +107,7 @@ func (s *Server) Serve(lis net.Listener) error {
 	registryErrors := s.monitorRegistry(lis.Addr())
 
 	// Peer's name is the registry's name.
-	name := s.registry.Name()
+	name := s.registry.Registry()
 
 	// Namespaced name, which just includes the namespace.
 	nsName, err := namespaceName(Peers, s.cfg.Namespace, name)


### PR DESCRIPTION
Add a doc block to how the fields of the `Registration` struct is used. It came up because of a bug where in "peer queries" the peer string would not be populated. That in turn made me think about the documentation around where does the peer name come from... it comes from the registry.