### PR TITLE
Report fatal errors when they happen.

### DIFF
--- a/grid.v3/mailbox.go
+++ b/grid.v3/mailbox.go
@@ -80,6 +80,14 @@ func newMailbox(s *Server, nsName string, size int) (*Mailbox, error) {
 	timeout, cancel := context.WithTimeout(context.Background(), s.cfg.Timeout)
 	err := s.registry.Register(timeout, nsName)
 	cancel()
+	// Check if the error is a particular fatal error
+	// from etcd. Some errors have no recovery. See
+	// the list of all possible errors here:
+	// 
+	// https://github.com/coreos/etcd/blob/master/etcdserver/api/v3rpc/rpctypes/error.go
+	//
+	// They are unfortunately not classidied into
+	// recoverable or non-recoverable.
 	if err != nil && strings.Contains(err.Error(), "etcdserver: requested lease not found") {
 		s.reportFatalError(err)
 		return nil, err

--- a/grid.v3/mailbox.go
+++ b/grid.v3/mailbox.go
@@ -1,6 +1,9 @@
 package grid
 
-import "context"
+import (
+	"context"
+	"strings"
+)
 
 // Mailbox for receiving messages.
 type Mailbox struct {
@@ -77,6 +80,10 @@ func newMailbox(s *Server, nsName string, size int) (*Mailbox, error) {
 	timeout, cancel := context.WithTimeout(context.Background(), s.cfg.Timeout)
 	err := s.registry.Register(timeout, nsName)
 	cancel()
+	if err != nil && strings.Contains(err.Error(), "etcdserver: requested lease not found") {
+		s.reportFatalError(err)
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Without this code change it is possible that during the use of keys under a lease report that the "requested lease not found", even though the lease keep-alive reports no error! With this code change such an error is report back to a monitor go-routine, which will start the shutdown of the server.