### PR TITLE
Expose the server context.

### DIFF
--- a/grid.v3/server_test.go
+++ b/grid.v3/server_test.go
@@ -72,6 +72,11 @@ func TestServerStartStop(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				select {
+				case <-server.Context().Done():
+				default:
+					t.Fatal("expected done context")
+				}
 				return
 			}
 		}

--- a/grid.v3/server_test.go
+++ b/grid.v3/server_test.go
@@ -59,6 +59,10 @@ func TestServerStartStop(t *testing.T) {
 		case <-time.After(timeout):
 			t.Fatal("timeout")
 		case <-a.started:
+			ctx := server.Context()
+			if ctx == nil {
+				t.Fatal("expected non-nil context on running server")
+			}
 			server.Stop()
 		case <-a.stopped:
 			select {


### PR DESCRIPTION
A supported use-case of grid is to just use mailboxes, ie: don't bother with the actors. Before this PR there was no way to know if the server has had some internal runtime error and needs to shutdown. The actors know this because they receive a context. Now users of just mailboxes can know this by using the server's context. To create a mailbox you must have the server, so anyone using a mailbox already has the server.