### PR TITLE
Using an interface instead of log.logger implementation for flexibility

### DIFF
--- a/cfg.go
+++ b/cfg.go
@@ -3,9 +3,13 @@ package grid
 import (
 	"runtime"
 	"time"
-
-	"github.com/lytics/grid/registry"
 )
+
+// Logger hides the logging function Printf behind a simple
+// interface so libraries such as logrus can be used.
+type Logger interface {
+	Printf(string, ...interface{})
+}
 
 // ClientCfg where the only required argument is Namespace,
 // other fields with their zero value will receive defaults.
@@ -22,7 +26,7 @@ type ClientCfg struct {
 	// but increases the number of file-handles used.
 	ConnectionsPerPeer int
 	// Logger optionally used for logging, default is to not log.
-	Logger registry.LogPrinter
+	Logger Logger
 }
 
 // setClientCfgDefaults for those fields that have their zero value.
@@ -50,7 +54,7 @@ type ServerCfg struct {
 	// LeaseDuration for data in etcd.
 	LeaseDuration time.Duration
 	// Logger optionally used for logging, default is to not log.
-	Logger registry.LogPrinter
+	Logger Logger
 }
 
 // setServerCfgDefaults for those fields that have their zero value.

--- a/cfg.go
+++ b/cfg.go
@@ -1,9 +1,10 @@
 package grid
 
 import (
-	"log"
 	"runtime"
 	"time"
+
+	"github.com/lytics/grid/registry"
 )
 
 // ClientCfg where the only required argument is Namespace,
@@ -21,7 +22,7 @@ type ClientCfg struct {
 	// but increases the number of file-handles used.
 	ConnectionsPerPeer int
 	// Logger optionally used for logging, default is to not log.
-	Logger *log.Logger
+	Logger registry.LogPrinter
 }
 
 // setClientCfgDefaults for those fields that have their zero value.
@@ -49,7 +50,7 @@ type ServerCfg struct {
 	// LeaseDuration for data in etcd.
 	LeaseDuration time.Duration
 	// Logger optionally used for logging, default is to not log.
-	Logger *log.Logger
+	Logger registry.LogPrinter
 }
 
 // setServerCfgDefaults for those fields that have their zero value.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -15,9 +15,10 @@ import (
 
 type Option int
 
-// LogPrinter hides the logging function Printf behind a simple
+// Logger hides the logging function Printf behind a simple
 // interface so libraries such as logrus can be used.
-type LogPrinter interface {
+// Copied from package grid to avoid interndependencies.
+type Logger interface {
 	Printf(string, ...interface{})
 }
 
@@ -103,7 +104,7 @@ type Registry struct {
 	client        *etcdv3.Client
 	name          string
 	address       string
-	Logger        LogPrinter
+	Logger        Logger
 	Timeout       time.Duration
 	LeaseDuration time.Duration
 	// Testing hook.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"strings"
 	"sync"
@@ -15,6 +14,12 @@ import (
 )
 
 type Option int
+
+// LogPrinter hides the logging function Printf behind a simple
+// interface so libraries such as logrus can be used.
+type LogPrinter interface {
+	Printf(string, ...interface{})
+}
 
 const (
 	// OpAllowReentrantRegistration will cause a registration
@@ -98,7 +103,7 @@ type Registry struct {
 	client        *etcdv3.Client
 	name          string
 	address       string
-	Logger        *log.Logger
+	Logger        LogPrinter
 	Timeout       time.Duration
 	LeaseDuration time.Duration
 	// Testing hook.


### PR DESCRIPTION
LogPrinter interface allows [logrus](https://github.com/sirupsen/logrus/blob/master/logger.go#L131) and other simple libs to fulfill the
Printf(...) implementation.