### PR TITLE
No etcd embed

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -59,7 +59,7 @@ func TestValidContext(t *testing.T) {
 
 	a := &contextActor{started: make(chan bool)}
 
-	server, err := NewServer(etcd, ServerCfg{Namespace: "testing"})
+	server, err := NewServer(etcd, ServerCfg{Namespace: newNamespace()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -54,8 +54,8 @@ func TestContextError(t *testing.T) {
 func TestValidContext(t *testing.T) {
 	const timeout = 2 * time.Second
 
-	etcd, cleanup := testetcd.StartAndConnect(t)
-	defer cleanup()
+	etcd := testetcd.StartAndConnect(t)
+	defer etcd.Close()
 
 	a := &contextActor{started: make(chan bool)}
 

--- a/name_test.go
+++ b/name_test.go
@@ -14,7 +14,7 @@ func TestIsNameValidEmpty(t *testing.T) {
 
 func TestIsNameValidBadChars(t *testing.T) {
 	for _, c := range strings.Split("( ) ` ~ ! @ # $ % ^ & * - + = | \\ { } [ ] : ; ' < > , . ? /", "") {
-		name := fmt.Sprintf("some-name-%s-that-is-bad")
+		name := fmt.Sprintf("some-name-@s-that-is-bad")
 		if isNameValid(name) {
 			t.Fatalf("expected false with name containing: %s", c)
 		}

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -1,0 +1,10 @@
+package grid
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+func newNamespace() string {
+	return fmt.Sprintf("test-namespace-%d", rand.Int63())
+}

--- a/query_test.go
+++ b/query_test.go
@@ -17,16 +17,18 @@ func TestQuery(t *testing.T) {
 		timeout = 1 * time.Second
 	)
 
+	namespace := newNamespace()
+
 	etcd, cleanup := testetcd.StartAndConnect(t)
 	defer cleanup()
 
-	c, err := NewClient(etcd, ClientCfg{Namespace: "testing"})
+	c, err := NewClient(etcd, ClientCfg{Namespace: namespace})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for i := 1; i <= nrPeers; i++ {
-		s, err := NewServer(etcd, ServerCfg{Namespace: "testing"})
+		s, err := NewServer(etcd, ServerCfg{Namespace: namespace})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -53,7 +55,7 @@ func TestQuery(t *testing.T) {
 		retry.X(6, backoff, func() bool {
 			peers, err = c.Query(timeout, Peers)
 			t.Logf("peers: %v", peers)
-			return err != nil
+			return err != nil || len(peers) != i
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -71,10 +73,12 @@ func TestQueryWatch(t *testing.T) {
 		timeout = 1 * time.Second
 	)
 
+	namespace := newNamespace()
+
 	etcd, cleanup := testetcd.StartAndConnect(t)
 	defer cleanup()
 
-	c, err := NewClient(etcd, ClientCfg{Namespace: "testing"})
+	c, err := NewClient(etcd, ClientCfg{Namespace: namespace})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +94,7 @@ func TestQueryWatch(t *testing.T) {
 	// Start servers one at a time in the background.
 	go func() {
 		for i := 1; i <= nrPeers; i++ {
-			s, err := NewServer(etcd, ServerCfg{Namespace: "testing"})
+			s, err := NewServer(etcd, ServerCfg{Namespace: namespace})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/query_test.go
+++ b/query_test.go
@@ -19,13 +19,14 @@ func TestQuery(t *testing.T) {
 
 	namespace := newNamespace()
 
-	etcd, cleanup := testetcd.StartAndConnect(t)
-	defer cleanup()
+	etcd := testetcd.StartAndConnect(t)
+	defer etcd.Close()
 
-	c, err := NewClient(etcd, ClientCfg{Namespace: namespace})
+	client, err := NewClient(etcd, ClientCfg{Namespace: namespace})
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer client.Close()
 
 	for i := 1; i <= nrPeers; i++ {
 		s, err := NewServer(etcd, ServerCfg{Namespace: namespace})
@@ -53,7 +54,7 @@ func TestQuery(t *testing.T) {
 		// Check for server as a peer.
 		var peers []*QueryEvent
 		retry.X(6, backoff, func() bool {
-			peers, err = c.Query(timeout, Peers)
+			peers, err = client.Query(timeout, Peers)
 			t.Logf("peers: %v", peers)
 			return err != nil || len(peers) != i
 		})
@@ -75,15 +76,16 @@ func TestQueryWatch(t *testing.T) {
 
 	namespace := newNamespace()
 
-	etcd, cleanup := testetcd.StartAndConnect(t)
-	defer cleanup()
+	etcd := testetcd.StartAndConnect(t)
+	defer etcd.Close()
 
-	c, err := NewClient(etcd, ClientCfg{Namespace: namespace})
+	client, err := NewClient(etcd, ClientCfg{Namespace: namespace})
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer client.Close()
 
-	initialPeers, watch, err := c.QueryWatch(context.Background(), Peers)
+	initialPeers, watch, err := client.QueryWatch(context.Background(), Peers)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -34,7 +34,7 @@ func TestServerStartStop(t *testing.T) {
 		stopped: make(chan bool),
 	}
 
-	server, err := NewServer(etcd, ServerCfg{Namespace: "testing"})
+	server, err := NewServer(etcd, ServerCfg{Namespace: newNamespace()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestServerWithFatalError(t *testing.T) {
 		stopped: make(chan bool),
 	}
 
-	server, err := NewServer(etcd, ServerCfg{Namespace: "testing"})
+	server, err := NewServer(etcd, ServerCfg{Namespace: newNamespace()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestServerStartNoEtcdRunning(t *testing.T) {
 	etcd, cleanup := testetcd.StartAndConnect(t)
 	cleanup()
 
-	server, err := NewServer(etcd, ServerCfg{Namespace: "testing"})
+	server, err := NewServer(etcd, ServerCfg{Namespace: newNamespace()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestServerStartThenEtcdStop(t *testing.T) {
 
 	etcd, cleanup := testetcd.StartAndConnect(t)
 
-	server, err := NewServer(etcd, ServerCfg{Namespace: "testing"})
+	server, err := NewServer(etcd, ServerCfg{Namespace: newNamespace()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -26,8 +26,8 @@ func TestServerStartStop(t *testing.T) {
 		timeout = 20 * time.Second
 	)
 
-	etcd, cleanup := testetcd.StartAndConnect(t)
-	defer cleanup()
+	etcd := testetcd.StartAndConnect(t)
+	defer etcd.Close()
 
 	a := &startStopActor{
 		started: make(chan bool),
@@ -88,8 +88,8 @@ func TestServerWithFatalError(t *testing.T) {
 		timeout = 20 * time.Second
 	)
 
-	etcd, cleanup := testetcd.StartAndConnect(t)
-	defer cleanup()
+	etcd := testetcd.StartAndConnect(t)
+	defer etcd.Close()
 
 	a := &startStopActor{
 		started: make(chan bool),
@@ -143,8 +143,8 @@ func TestServerStartNoEtcdRunning(t *testing.T) {
 	)
 
 	// Start etcd, but shut it down right away.
-	etcd, cleanup := testetcd.StartAndConnect(t)
-	cleanup()
+	etcd := testetcd.StartAndConnect(t)
+	etcd.Close()
 
 	server, err := NewServer(etcd, ServerCfg{Namespace: newNamespace()})
 	if err != nil {
@@ -170,7 +170,8 @@ func TestServerStartThenEtcdStop(t *testing.T) {
 		stopped: make(chan bool),
 	}
 
-	etcd, cleanup := testetcd.StartAndConnect(t)
+	etcd := testetcd.StartAndConnect(t)
+	defer etcd.Close()
 
 	server, err := NewServer(etcd, ServerCfg{Namespace: newNamespace()})
 	if err != nil {
@@ -199,7 +200,7 @@ func TestServerStartThenEtcdStop(t *testing.T) {
 				t.Fatal(err)
 			}
 		case <-a.started:
-			err := cleanup()
+			err := etcd.Close()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/testetcd/etcdserver.go
+++ b/testetcd/etcdserver.go
@@ -1,32 +1,16 @@
 package testetcd
 
 import (
-	"fmt"
-	"io/ioutil"
-	"net"
-	"net/url"
-	"os"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/embed"
-	"github.com/coreos/pkg/capnslog"
 )
 
 type Cleanup func() error
 
 func StartAndConnect(t testing.TB) (*clientv3.Client, Cleanup) {
-	srvCfg, cleanup := Start(t)
-
-	endpoints := []string{}
-	for _, u := range srvCfg.LCUrls {
-		endpoints = append(endpoints, u.String())
-	}
-
 	cfg := clientv3.Config{
-		Endpoints: endpoints,
+		Endpoints: []string{"localhost:2379"},
 	}
 
 	etcd, err := clientv3.New(cfg)
@@ -34,101 +18,101 @@ func StartAndConnect(t testing.TB) (*clientv3.Client, Cleanup) {
 		t.Fatal(err)
 	}
 
-	return etcd, cleanup
+	return etcd, etcd.Close
 }
 
-func Start(t testing.TB) (*embed.Config, Cleanup) {
-	cfg := embed.NewConfig()
-	dir, _ := ioutil.TempDir("", "etcd.testserver.")
-	cfg.Dir = dir
+// func Start(t testing.TB) (*embed.Config, Cleanup) {
+// 	cfg := embed.NewConfig()
+// 	dir, _ := ioutil.TempDir("", "etcd.testserver.")
+// 	cfg.Dir = dir
 
-	lPUrls, lCUrls, aPUrls, aCUrls := findFreeEtcdUrls()
-	cfg.LPUrls = lPUrls
-	cfg.LCUrls = lCUrls
-	cfg.APUrls = aPUrls
-	cfg.ACUrls = aCUrls
-	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name) //dumb magic that has to be called after updating the URLs.
-	cfg.Debug = true
+// 	lPUrls, lCUrls, aPUrls, aCUrls := findFreeEtcdUrls()
+// 	cfg.LPUrls = lPUrls
+// 	cfg.LCUrls = lCUrls
+// 	cfg.APUrls = aPUrls
+// 	cfg.ACUrls = aCUrls
+// 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name) //dumb magic that has to be called after updating the URLs.
+// 	cfg.Debug = true
 
-	f, err := os.Create(cfg.Dir + "/" + "etcd.log")
-	if err != nil {
-		t.Fatal(err)
-	}
-	//comment out to get etcd logs on stderr
-	capnslog.SetFormatter(capnslog.NewPrettyFormatter(f, cfg.Debug))
+// 	f, err := os.Create(cfg.Dir + "/" + "etcd.log")
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	//comment out to get etcd logs on stderr
+// 	capnslog.SetFormatter(capnslog.NewPrettyFormatter(f, cfg.Debug))
 
-	e, err := embed.StartEtcd(cfg)
-	if err != nil {
-		t.Fatal(t)
-	}
+// 	e, err := embed.StartEtcd(cfg)
+// 	if err != nil {
+// 		t.Fatal(t)
+// 	}
 
-	select {
-	case <-e.Server.ReadyNotify():
-	case <-time.After(60 * time.Second):
-		e.Server.Stop()
-		t.Fatal(err)
-	}
+// 	select {
+// 	case <-e.Server.ReadyNotify():
+// 	case <-time.After(60 * time.Second):
+// 		e.Server.Stop()
+// 		t.Fatal(err)
+// 	}
 
-	select {
-	case err := <-e.Err():
-		t.Fatal(err)
-	default:
-	}
+// 	select {
+// 	case err := <-e.Err():
+// 		t.Fatal(err)
+// 	default:
+// 	}
 
-	return cfg, func() error {
-		e.Close()
-		select {
-		case err := <-e.Err():
-			if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-				return fmt.Errorf("closing server returned error: %v", err)
-			}
-		default:
-		}
-		return os.RemoveAll(cfg.Dir)
-	}
-}
+// 	return cfg, func() error {
+// 		e.Close()
+// 		select {
+// 		case err := <-e.Err():
+// 			if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+// 				return fmt.Errorf("closing server returned error: %v", err)
+// 			}
+// 		default:
+// 		}
+// 		return os.RemoveAll(cfg.Dir)
+// 	}
+// }
 
-func findFreeEtcdUrls() (lPUrls []url.URL, lCUrls []url.URL, aPUrls []url.URL, aCUrls []url.URL) {
-	l1, _ := net.Listen("tcp", ":0")
-	defer l1.Close()
-	p1 := l1.Addr().(*net.TCPAddr).Port
+// func findFreeEtcdUrls() (lPUrls []url.URL, lCUrls []url.URL, aPUrls []url.URL, aCUrls []url.URL) {
+// 	l1, _ := net.Listen("tcp", ":0")
+// 	defer l1.Close()
+// 	p1 := l1.Addr().(*net.TCPAddr).Port
 
-	l2, _ := net.Listen("tcp", ":0")
-	defer l2.Close()
-	p2 := l2.Addr().(*net.TCPAddr).Port
+// 	l2, _ := net.Listen("tcp", ":0")
+// 	defer l2.Close()
+// 	p2 := l2.Addr().(*net.TCPAddr).Port
 
-	lh1 := fmt.Sprintf("http://localhost:%d", p1)
-	lh2 := fmt.Sprintf("http://localhost:%d", p2)
-	localUrl1, _ := url.Parse(lh1)
-	localUrl2, _ := url.Parse(lh2)
+// 	lh1 := fmt.Sprintf("http://localhost:%d", p1)
+// 	lh2 := fmt.Sprintf("http://localhost:%d", p2)
+// 	localUrl1, _ := url.Parse(lh1)
+// 	localUrl2, _ := url.Parse(lh2)
 
-	lPUrls = []url.URL{*localUrl1}
-	lCUrls = []url.URL{*localUrl2}
+// 	lPUrls = []url.URL{*localUrl1}
+// 	lCUrls = []url.URL{*localUrl2}
 
-	ip := getLocalIP()
-	ah1 := fmt.Sprintf("http://%s:%d", ip, p1)
-	ah2 := fmt.Sprintf("http://%s:%d", ip, p2)
-	adUrl1, _ := url.Parse(ah1)
-	adUrl2, _ := url.Parse(ah2)
+// 	ip := getLocalIP()
+// 	ah1 := fmt.Sprintf("http://%s:%d", ip, p1)
+// 	ah2 := fmt.Sprintf("http://%s:%d", ip, p2)
+// 	adUrl1, _ := url.Parse(ah1)
+// 	adUrl2, _ := url.Parse(ah2)
 
-	aPUrls = []url.URL{*adUrl1}
-	aCUrls = []url.URL{*adUrl2}
-	return
-}
+// 	aPUrls = []url.URL{*adUrl1}
+// 	aCUrls = []url.URL{*adUrl2}
+// 	return
+// }
 
-// getLocalIP returns the non loopback local IP of the host
-func getLocalIP() string {
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return ""
-	}
-	for _, address := range addrs {
-		// check the address type and if it is not a loopback the display it
-		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			if ipnet.IP.To4() != nil {
-				return ipnet.IP.String()
-			}
-		}
-	}
-	return ""
-}
+// // getLocalIP returns the non loopback local IP of the host
+// func getLocalIP() string {
+// 	addrs, err := net.InterfaceAddrs()
+// 	if err != nil {
+// 		return ""
+// 	}
+// 	for _, address := range addrs {
+// 		// check the address type and if it is not a loopback the display it
+// 		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+// 			if ipnet.IP.To4() != nil {
+// 				return ipnet.IP.String()
+// 			}
+// 		}
+// 	}
+// 	return ""
+// }

--- a/testetcd/etcdserver.go
+++ b/testetcd/etcdserver.go
@@ -6,9 +6,7 @@ import (
 	"github.com/coreos/etcd/clientv3"
 )
 
-type Cleanup func() error
-
-func StartAndConnect(t testing.TB) (*clientv3.Client, Cleanup) {
+func StartAndConnect(t testing.TB) *clientv3.Client {
 	cfg := clientv3.Config{
 		Endpoints: []string{"localhost:2379"},
 	}
@@ -18,101 +16,5 @@ func StartAndConnect(t testing.TB) (*clientv3.Client, Cleanup) {
 		t.Fatal(err)
 	}
 
-	return etcd, etcd.Close
+	return etcd
 }
-
-// func Start(t testing.TB) (*embed.Config, Cleanup) {
-// 	cfg := embed.NewConfig()
-// 	dir, _ := ioutil.TempDir("", "etcd.testserver.")
-// 	cfg.Dir = dir
-
-// 	lPUrls, lCUrls, aPUrls, aCUrls := findFreeEtcdUrls()
-// 	cfg.LPUrls = lPUrls
-// 	cfg.LCUrls = lCUrls
-// 	cfg.APUrls = aPUrls
-// 	cfg.ACUrls = aCUrls
-// 	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name) //dumb magic that has to be called after updating the URLs.
-// 	cfg.Debug = true
-
-// 	f, err := os.Create(cfg.Dir + "/" + "etcd.log")
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	//comment out to get etcd logs on stderr
-// 	capnslog.SetFormatter(capnslog.NewPrettyFormatter(f, cfg.Debug))
-
-// 	e, err := embed.StartEtcd(cfg)
-// 	if err != nil {
-// 		t.Fatal(t)
-// 	}
-
-// 	select {
-// 	case <-e.Server.ReadyNotify():
-// 	case <-time.After(60 * time.Second):
-// 		e.Server.Stop()
-// 		t.Fatal(err)
-// 	}
-
-// 	select {
-// 	case err := <-e.Err():
-// 		t.Fatal(err)
-// 	default:
-// 	}
-
-// 	return cfg, func() error {
-// 		e.Close()
-// 		select {
-// 		case err := <-e.Err():
-// 			if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-// 				return fmt.Errorf("closing server returned error: %v", err)
-// 			}
-// 		default:
-// 		}
-// 		return os.RemoveAll(cfg.Dir)
-// 	}
-// }
-
-// func findFreeEtcdUrls() (lPUrls []url.URL, lCUrls []url.URL, aPUrls []url.URL, aCUrls []url.URL) {
-// 	l1, _ := net.Listen("tcp", ":0")
-// 	defer l1.Close()
-// 	p1 := l1.Addr().(*net.TCPAddr).Port
-
-// 	l2, _ := net.Listen("tcp", ":0")
-// 	defer l2.Close()
-// 	p2 := l2.Addr().(*net.TCPAddr).Port
-
-// 	lh1 := fmt.Sprintf("http://localhost:%d", p1)
-// 	lh2 := fmt.Sprintf("http://localhost:%d", p2)
-// 	localUrl1, _ := url.Parse(lh1)
-// 	localUrl2, _ := url.Parse(lh2)
-
-// 	lPUrls = []url.URL{*localUrl1}
-// 	lCUrls = []url.URL{*localUrl2}
-
-// 	ip := getLocalIP()
-// 	ah1 := fmt.Sprintf("http://%s:%d", ip, p1)
-// 	ah2 := fmt.Sprintf("http://%s:%d", ip, p2)
-// 	adUrl1, _ := url.Parse(ah1)
-// 	adUrl2, _ := url.Parse(ah2)
-
-// 	aPUrls = []url.URL{*adUrl1}
-// 	aCUrls = []url.URL{*adUrl2}
-// 	return
-// }
-
-// // getLocalIP returns the non loopback local IP of the host
-// func getLocalIP() string {
-// 	addrs, err := net.InterfaceAddrs()
-// 	if err != nil {
-// 		return ""
-// 	}
-// 	for _, address := range addrs {
-// 		// check the address type and if it is not a loopback the display it
-// 		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-// 			if ipnet.IP.To4() != nil {
-// 				return ipnet.IP.String()
-// 			}
-// 		}
-// 	}
-// 	return ""
-// }


### PR DESCRIPTION
Remove use of etcd embed. Real etcd needs to be running for tests. All tests pass and use a different namespace in etcd so that they do not step on each other.