### PR TITLE
Add the ability to specify annotations for a grid peer

### DIFF
--- a/cfg.go
+++ b/cfg.go
@@ -55,6 +55,8 @@ type ServerCfg struct {
 	LeaseDuration time.Duration
 	// Logger optionally used for logging, default is to not log.
 	Logger Logger
+	// Annotations optionally used annotating a grid server with metadata
+	Annotations map[string]string
 }
 
 // setServerCfgDefaults for those fields that have their zero value.

--- a/cfg.go
+++ b/cfg.go
@@ -56,7 +56,7 @@ type ServerCfg struct {
 	// Logger optionally used for logging, default is to not log.
 	Logger Logger
 	// Annotations optionally used annotating a grid server with metadata
-	Annotations map[string]string
+	Annotations []string
 }
 
 // setServerCfgDefaults for those fields that have their zero value.

--- a/query.go
+++ b/query.go
@@ -53,6 +53,12 @@ func (e *QueryEvent) Peer() string {
 	return e.peer
 }
 
+// Annotations of named entity.
+// Currently only used by Peers as an option to the grid server.
+func (e *QueryEvent) Annotations() []string {
+	return e.annotations
+}
+
 // Err caught watching query events. The error is
 // not associated with any particular entity, it's
 // an error with the watch itself or a result of

--- a/query.go
+++ b/query.go
@@ -31,11 +31,12 @@ const (
 // QueryEvent indicating that an entity has been discovered,
 // lost, or some error has occured with the watch.
 type QueryEvent struct {
-	name   string
-	peer   string
-	err    error
-	entity EntityType
-	Type   EventType
+	name        string
+	peer        string
+	err         error
+	entity      EntityType
+	Type        EventType
+	annotations []string
 }
 
 // Name of entity that caused the event. For example, if
@@ -109,10 +110,11 @@ func (c *Client) QueryWatch(ctx context.Context, filter EntityType) ([]*QueryEve
 	var current []*QueryEvent
 	for _, reg := range regs {
 		current = append(current, &QueryEvent{
-			name:   nameFromKey(filter, c.cfg.Namespace, reg.Key),
-			peer:   reg.Registry,
-			entity: filter,
-			Type:   EntityFound,
+			name:        nameFromKey(filter, c.cfg.Namespace, reg.Key),
+			peer:        reg.Registry,
+			entity:      filter,
+			annotations: reg.Annotations,
+			Type:        EntityFound,
 		})
 	}
 
@@ -150,9 +152,10 @@ func (c *Client) QueryWatch(ctx context.Context, filter EntityType) ([]*QueryEve
 				switch change.Type {
 				case registry.Delete:
 					qe := &QueryEvent{
-						name:   nameFromKey(filter, c.cfg.Namespace, change.Key),
-						entity: filter,
-						Type:   EntityLost,
+						name:        nameFromKey(filter, c.cfg.Namespace, change.Key),
+						entity:      filter,
+						annotations: change.Reg.Annotations,
+						Type:        EntityLost,
 					}
 					// Maintain contract that for peer events
 					// the Peer() and Name() methods return
@@ -168,10 +171,11 @@ func (c *Client) QueryWatch(ctx context.Context, filter EntityType) ([]*QueryEve
 					put(qe)
 				case registry.Create, registry.Modify:
 					qe := &QueryEvent{
-						name:   nameFromKey(filter, c.cfg.Namespace, change.Key),
-						peer:   change.Reg.Registry,
-						entity: filter,
-						Type:   EntityFound,
+						name:        nameFromKey(filter, c.cfg.Namespace, change.Key),
+						peer:        change.Reg.Registry,
+						entity:      filter,
+						annotations: change.Reg.Annotations,
+						Type:        EntityFound,
 					}
 					// Maintain contract that for peer events
 					// the Peer() and Name() methods return

--- a/query.go
+++ b/query.go
@@ -157,10 +157,14 @@ func (c *Client) QueryWatch(ctx context.Context, filter EntityType) ([]*QueryEve
 				}
 				switch change.Type {
 				case registry.Delete:
+					annotations := []string{}
+					if change.Reg != nil {
+						annotations = change.Reg.Annotations
+					}
 					qe := &QueryEvent{
 						name:        nameFromKey(filter, c.cfg.Namespace, change.Key),
 						entity:      filter,
-						annotations: change.Reg.Annotations,
+						annotations: annotations,
 						Type:        EntityLost,
 					}
 					// Maintain contract that for peer events

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -52,7 +52,7 @@ type Registration struct {
 func (r *Registration) String() string {
 	sort.Strings(r.Annotations)
 	return fmt.Sprintf("key: %v, address: %v, registry: %v, annotations: %v",
-		r.Key, r.Address, r.Registry, strings.Join(sorted, ","))
+		r.Key, r.Address, r.Registry, strings.Join(r.Annotations, ","))
 }
 
 // EventType of a watch event.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -398,19 +398,6 @@ func (rr *Registry) Register(c context.Context, key string, annotations ...strin
 	}
 
 	if getRes.Count > 0 {
-		kv := getRes.Kvs[0]
-		// check if the found record has the correct address.
-		reg := &Registration{}
-		err = json.Unmarshal(kv.Value, reg)
-		if err != nil {
-			return err
-		}
-		// The caller is already registered and they
-		// have allowed just multi-registration, so
-		// return.
-		if reg.Address == rr.address {
-			return nil
-		}
 		// The caller is regestering a key that is
 		// already registered by another address.
 		return ErrAlreadyRegistered

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -20,8 +20,6 @@ type Logger interface {
 	Printf(string, ...interface{})
 }
 
-const ()
-
 var (
 	ErrNotOwner                    = errors.New("registry: not owner")
 	ErrNotStarted                  = errors.New("registry: not started")
@@ -406,15 +404,7 @@ func (rr *Registry) Register(c context.Context, key string, annotations ...map[s
 
 	if getRes.Count > 0 {
 		kv := getRes.Kvs[0]
-		// The keys mach, so check if the caller has
-		// allowed multiple registrations from the
-		// same address.
-		if !opt.AllowReentrantRegistration {
-			return ErrAlreadyRegistered
-		}
-		// The call HAS allowed multiple registrations
-		// from the same address, so check if the
-		// found record has the correct address.
+		// check if the found record has the correct address.
 		reg := &Registration{}
 		err = json.Unmarshal(kv.Value, reg)
 		if err != nil {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -34,7 +34,6 @@ var (
 	ErrWatchClosedUnexpectedly     = errors.New("registry: watch closed unexpectedly")
 	ErrUnspecifiedNetAddressIP     = errors.New("registry: unspecified net address ip")
 	ErrKeepAliveClosedUnexpectedly = errors.New("registry: keep alive closed unexpectedly")
-	ErrInvalidAnnotationsOption    = errors.New("registry: invalid annotations option")
 )
 
 var (

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -140,21 +140,6 @@ func TestRegisterDeregisterWhileNotStarted(t *testing.T) {
 	}
 }
 
-func TestRegisterTwiceAllowed(t *testing.T) {
-	client, r, _ := bootstrap(t, start)
-	defer client.Close()
-	defer r.Stop()
-
-	for i := 0; i < 2; i++ {
-		timeout, cancel := timeoutContext()
-		err := r.Register(timeout, "test-registration-twice", OpAllowReentrantRegistration)
-		cancel()
-		if i > 0 && err == ErrAlreadyRegistered {
-			t.Fatal("not allowed to register twice")
-		}
-	}
-}
-
 func TestRegisterTwiceNotAllowed(t *testing.T) {
 	client, r, _ := bootstrap(t, start)
 	defer client.Close()

--- a/server.go
+++ b/server.go
@@ -132,7 +132,7 @@ func (s *Server) Serve(lis net.Listener) error {
 	// Register the namespace name, other peers can search
 	// for this to discover each other.
 	timeoutC, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
-	err = s.registry.Register(timeoutC, nsName)
+	err = s.registry.Register(timeoutC, nsName, s.cfg.Annotations)
 	cancel()
 	if err != nil {
 		return err

--- a/server.go
+++ b/server.go
@@ -132,7 +132,7 @@ func (s *Server) Serve(lis net.Listener) error {
 	// Register the namespace name, other peers can search
 	// for this to discover each other.
 	timeoutC, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
-	err = s.registry.Register(timeoutC, nsName, s.cfg.Annotations)
+	err = s.registry.Register(timeoutC, nsName, s.cfg.Annotations...)
 	cancel()
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit adds the ability to pass in annotations to the grid server
config which gets stored in etcd and can be retrieved in a peer query by
other grid servers. This will allow systems to partition actors across
peers depending on their annotations.