### PR TITLE
Panic on failures to deregister actors

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,10 +10,10 @@ import (
 	"sync"
 	"time"
 
-	etcdv3 "go.etcd.io/etcd/clientv3"
 	"github.com/lytics/grid/codec"
 	"github.com/lytics/grid/registry"
 	"github.com/lytics/retry"
+	etcdv3 "go.etcd.io/etcd/clientv3"
 	"google.golang.org/grpc"
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"go.etcd.io/etcd/clientv3"
 	"github.com/lytics/grid/testetcd"
+	"go.etcd.io/etcd/clientv3"
 )
 
 type busyActor struct {

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	etcdv3 "go.etcd.io/etcd/clientv3"
 	"github.com/lytics/grid"
+	etcdv3 "go.etcd.io/etcd/clientv3"
 )
 
 const timeout = 2 * time.Second

--- a/examples/requestreply/main.go
+++ b/examples/requestreply/main.go
@@ -16,8 +16,8 @@ import (
 	"syscall"
 	"time"
 
-	etcdv3 "go.etcd.io/etcd/clientv3"
 	"github.com/lytics/grid"
+	etcdv3 "go.etcd.io/etcd/clientv3"
 )
 
 var (

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -159,9 +159,7 @@ func (rr *Registry) Start(addr net.Addr) (<-chan error, error) {
 	//     1) Someone calls Stop, in which case it will cancel
 	//        its context and exit.
 	//     2) The Registry fails to signal keep-alive on it
-	//        lease repeatedly, in which case it will cancel
-	//        its context and exit.
-	failure := make(chan error, 1)
+	//        lease repeatedly, in which case it will panic.
 	go func() {
 		defer close(rr.exited)
 
@@ -189,16 +187,7 @@ func (rr *Registry) Start(addr net.Addr) (<-chan error, error) {
 						return
 					default:
 					}
-					select {
-					case failure <- ErrKeepAliveClosedUnexpectedly:
-						// Testing hook.
-						if stats != nil {
-							stats.failure++
-						}
-						rr.logf("registry: %v: keep alive closed unexpectedly", rr.name)
-					default:
-					}
-					return
+					panic("registry: %v: keep alive closed unexpectedly", rr.name)
 				}
 				rr.logf("registry: %v: keep alive responded with heartbeat TTL: %vs", rr.name, res.TTL)
 				// Testing hook.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -123,7 +123,7 @@ func New(client *etcdv3.Client) (*Registry, error) {
 }
 
 // Start Registry.
-func (rr *Registry) Start(addr net.Addr) (<-chan error, error) {
+func (rr *Registry) Start(addr net.Addr) error {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
 
@@ -198,7 +198,7 @@ func (rr *Registry) Start(addr net.Addr) (<-chan error, error) {
 		}
 	}()
 
-	return failure, nil
+	return nil
 }
 
 // Address of this registry in the format of <ip>:<port>

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -129,13 +129,13 @@ func (rr *Registry) Start(addr net.Addr) error {
 
 	address, err := formatAddress(addr)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	rr.address = address
 	rr.name = formatName(address)
 
 	if rr.LeaseDuration < minLeaseDuration {
-		return nil, ErrLeaseDurationTooShort
+		return ErrLeaseDurationTooShort
 	}
 	rr.lease = etcdv3.NewLease(rr.client)
 
@@ -143,7 +143,7 @@ func (rr *Registry) Start(addr net.Addr) error {
 	res, err := rr.lease.Grant(timeout, int64(rr.LeaseDuration.Seconds()))
 	cancel()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	rr.leaseID = res.ID
 
@@ -152,7 +152,7 @@ func (rr *Registry) Start(addr net.Addr) error {
 	keepAlive, err := rr.lease.KeepAlive(keepAliveCtx, rr.leaseID)
 	if err != nil {
 		keepAliveCancel()
-		return nil, err
+		return err
 	}
 
 	// There are two ways the Registry can exit:
@@ -187,7 +187,7 @@ func (rr *Registry) Start(addr net.Addr) error {
 						return
 					default:
 					}
-					panic("registry: %v: keep alive closed unexpectedly", rr.name)
+					panic(fmt.Sprintf("registry: %v: keep alive closed unexpectedly", rr.name))
 				}
 				rr.logf("registry: %v: keep alive responded with heartbeat TTL: %vs", rr.name, res.TTL)
 				// Testing hook.

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -256,7 +256,7 @@ func TestKeepAlive(t *testing.T) {
 
 	// Use the minimum.
 	r.LeaseDuration = 1 * time.Second
-	_, err := r.Start(addr)
+	err := r.Start(addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestWatch(t *testing.T) {
 
 	// Use the minimum.
 	r.LeaseDuration = 1 * time.Second
-	_, err := r.Start(addr)
+	err := r.Start(addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -429,7 +429,7 @@ func bootstrap(t *testing.T, shouldStart bool) (*etcdv3.Client, *Registry, *net.
 	r.LeaseDuration = 10 * time.Second
 
 	if shouldStart {
-		_, err = r.Start(addr)
+		err = r.Start(addr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	etcdv3 "go.etcd.io/etcd/clientv3"
 	"github.com/lytics/grid/testetcd"
+	etcdv3 "go.etcd.io/etcd/clientv3"
 )
 
 const (

--- a/server.go
+++ b/server.go
@@ -439,7 +439,7 @@ func (s *Server) startActorC(c context.Context, start *ActorStart) error {
 		defer func() {
 			var err error
 			retry.X(3, 3*time.Second,
-				func() error {
+				func() bool {
 					timeout, cancel := context.WithTimeout(context.Background(), s.cfg.Timeout)
 					err = s.registry.Deregister(timeout, nsName)
 					cancel()

--- a/server.go
+++ b/server.go
@@ -303,14 +303,6 @@ func (s *Server) monitorFatalErrors() {
 	}()
 }
 
-// monitorRegistry for errors in the background.
-func (s *Server) monitorRegistry(addr net.Addr) error {
-	if err := ; err != nil {
-		return err
-	}
-	return nil
-}
-
 // monitorLeader starts a leader and keeps tyring to start
 // a leader thereafter. If the leader should die on any
 // host then some peer will eventually have it start again.

--- a/server.go
+++ b/server.go
@@ -114,10 +114,7 @@ func (s *Server) Serve(lis net.Listener) error {
 	s.ctx = ctx
 	s.cancel = cancel
 
-	// Start the registry and monitor that it is
-	// running correctly.
-	err = s.monitorRegistry(lis.Addr())
-	if err != nil {
+	if s.registry.Start(lis.Addr()); err != nil {
 		return err
 	}
 
@@ -308,18 +305,9 @@ func (s *Server) monitorFatalErrors() {
 
 // monitorRegistry for errors in the background.
 func (s *Server) monitorRegistry(addr net.Addr) error {
-	regFaults, err := s.registry.Start(addr)
-	if err != nil {
+	if err := ; err != nil {
 		return err
 	}
-	go func() {
-		select {
-		case <-s.ctx.Done():
-			return
-		case err := <-regFaults:
-			s.reportFatalError(err)
-		}
-	}()
 	return nil
 }
 

--- a/server.go
+++ b/server.go
@@ -463,7 +463,7 @@ func (s *Server) startActorC(c context.Context, start *ActorStart) error {
 					timeout, cancel := context.WithTimeout(context.Background(), s.cfg.Timeout)
 					err = s.registry.Deregister(timeout, nsName)
 					cancel()
-					return err == nil
+					return err != nil
 				})
 			if err != nil {
 				s.logf("failed to deregister actor: %v, error: %v", nsName, err)

--- a/server.go
+++ b/server.go
@@ -439,7 +439,7 @@ func (s *Server) startActorC(c context.Context, start *ActorStart) error {
 		defer func() {
 			var err error
 			retry.X(3, 3*time.Second,
-				func() {
+				func() error {
 					timeout, cancel := context.WithTimeout(context.Background(), s.cfg.Timeout)
 					err = s.registry.Deregister(timeout, nsName)
 					cancel()

--- a/server.go
+++ b/server.go
@@ -447,7 +447,7 @@ func (s *Server) startActorC(c context.Context, start *ActorStart) error {
 				})
 			if err != nil {
 				s.logf("failed to deregister actor: %v, error: %v", nsName, err)
-				panic("unable to deregister actor: %v, error: %v", nsName, err)
+				panic(fmt.Sprintf("unable to deregister actor: %v, error: %v", nsName, err))
 			}
 		}()
 		defer func() {


### PR DESCRIPTION
https://github.com/lytics/lio/issues/16064

This PR fixes an issue where if we failed to deregister and actor from etcd the server would never shutdown that actor meaning that other actors would not be able to restart to take it's place. This makes sure we bring down the whole server if this happens.