### PR TITLE
Allocation per Operation and Lock management optimizations

### DIFF
--- a/bench/Readme.md
+++ b/bench/Readme.md
@@ -1,43 +1,34 @@
-
-
-
-
-
-
-
-
-
-
-
 #### Results: 
 
 
-#### Results after just adding the benchmark test on commit: 5f8bf8a3fec64e2df6d1032381a6084028fd7867
+#### Results after just adding the benchmark test on commit: 5f8bf8a3fec64e2df6d1032381a6084028fd7867 (Base line no changes)
 
-Started embedded etcd on url: http://localhost:21692goos: darwin
-goarch: amd64
-pkg: github.com/lytics/grid/bench
 BenchmarkClientServerRoundTripSmallMsg-12                  11257            105941 ns/op           17392 B/op        290 allocs/op
 BenchmarkClientServerRoundTripBigStrMsg-12                  9408            127801 ns/op           71079 B/op        293 allocs/op
 BenchmarkClientServerRoundTripBigMapBigStrMsg-12            3555            309087 ns/op          187275 B/op       2725 allocs/op
-PASS
-ok      github.com/lytics/grid/bench    8.211s
-Started embedded etcd on url: http://localhost:11899goos: darwin
-goarch: amd64
-pkg: github.com/lytics/grid/bench
+
 BenchmarkClientServerRoundTripSmallMsg-12                  10671            107704 ns/op           17393 B/op        290 allocs/op
 BenchmarkClientServerRoundTripBigStrMsg-12                  8620            132313 ns/op           71168 B/op        293 allocs/op
 BenchmarkClientServerRoundTripBigMapBigStrMsg-12            3576            315491 ns/op          187284 B/op       2725 allocs/op
-PASS
-ok      github.com/lytics/grid/bench    7.180s
-Started embedded etcd on url: http://localhost:3762goos: darwin
-goarch: amd64
-pkg: github.com/lytics/grid/bench
+
 BenchmarkClientServerRoundTripSmallMsg-12                  11174            110227 ns/op           17395 B/op        290 allocs/op
 BenchmarkClientServerRoundTripBigStrMsg-12                  8658            139203 ns/op           71103 B/op        293 allocs/op
 BenchmarkClientServerRoundTripBigMapBigStrMsg-12            3556            315230 ns/op          187242 B/op       2725 allocs/op
-PASS
-ok      github.com/lytics/grid/bench    7.943s
 
+#### Results after just adding the benchmark test on commit: dad755d6cb11f4daab738eec8133554a7c3c48e7 (pre-compiled names regex)
+
+*Just focusing on optimizing Allocations per Operation for this set of changes*
+
+BenchmarkClientServerRoundTripSmallMsg-12                  11971             94264 ns/op           11850 B/op        208 allocs/op
+BenchmarkClientServerRoundTripBigStrMsg-12                  9106            114902 ns/op           65520 B/op        211 allocs/op
+BenchmarkClientServerRoundTripBigMapBigStrMsg-12            3831            298895 ns/op          181501 B/op       2642 allocs/op
+
+BenchmarkClientServerRoundTripSmallMsg-12                  12870             92300 ns/op           11848 B/op        208 allocs/op
+BenchmarkClientServerRoundTripBigStrMsg-12                  9277            114179 ns/op           65505 B/op        211 allocs/op
+BenchmarkClientServerRoundTripBigMapBigStrMsg-12            3537            293994 ns/op          181645 B/op       2642 allocs/op
+
+BenchmarkClientServerRoundTripSmallMsg-12                  12685             92157 ns/op           11848 B/op        208 allocs/op
+BenchmarkClientServerRoundTripBigStrMsg-12                  9462            115722 ns/op           65519 B/op        211 allocs/op
+BenchmarkClientServerRoundTripBigMapBigStrMsg-12            3644            295176 ns/op          181563 B/op       2642 allocs/op
 
 

--- a/bench/Readme.md
+++ b/bench/Readme.md
@@ -12,21 +12,32 @@
 #### Results: 
 
 
-#### Results after just adding the benchmark test on commit: 149ba86c2546953b25d7b3fedcfe57f639bfceec
+#### Results after just adding the benchmark test on commit: 5f8bf8a3fec64e2df6d1032381a6084028fd7867
 
-NOTE: I was running a complete backup while running these test, so I want to rerun this after that completes.
+Started embedded etcd on url: http://localhost:21692goos: darwin
+goarch: amd64
+pkg: github.com/lytics/grid/bench
+BenchmarkClientServerRoundTripSmallMsg-12                  11257            105941 ns/op           17392 B/op        290 allocs/op
+BenchmarkClientServerRoundTripBigStrMsg-12                  9408            127801 ns/op           71079 B/op        293 allocs/op
+BenchmarkClientServerRoundTripBigMapBigStrMsg-12            3555            309087 ns/op          187275 B/op       2725 allocs/op
+PASS
+ok      github.com/lytics/grid/bench    8.211s
+Started embedded etcd on url: http://localhost:11899goos: darwin
+goarch: amd64
+pkg: github.com/lytics/grid/bench
+BenchmarkClientServerRoundTripSmallMsg-12                  10671            107704 ns/op           17393 B/op        290 allocs/op
+BenchmarkClientServerRoundTripBigStrMsg-12                  8620            132313 ns/op           71168 B/op        293 allocs/op
+BenchmarkClientServerRoundTripBigMapBigStrMsg-12            3576            315491 ns/op          187284 B/op       2725 allocs/op
+PASS
+ok      github.com/lytics/grid/bench    7.180s
+Started embedded etcd on url: http://localhost:3762goos: darwin
+goarch: amd64
+pkg: github.com/lytics/grid/bench
+BenchmarkClientServerRoundTripSmallMsg-12                  11174            110227 ns/op           17395 B/op        290 allocs/op
+BenchmarkClientServerRoundTripBigStrMsg-12                  8658            139203 ns/op           71103 B/op        293 allocs/op
+BenchmarkClientServerRoundTripBigMapBigStrMsg-12            3556            315230 ns/op          187242 B/op       2725 allocs/op
+PASS
+ok      github.com/lytics/grid/bench    7.943s
 
----
-BenchmarkClientServerRoundTripSmallMsg-12                   8876            136011 ns/op
-BenchmarkClientServerRoundTripBigStrMsg-12                  7065            180048 ns/op
-BenchmarkClientServerRoundTripBigMapBigStrMsg-12            2137            504521 ns/op
----
-BenchmarkClientServerRoundTripSmallMsg-12                   7275            147101 ns/op
-BenchmarkClientServerRoundTripBigStrMsg-12                  6042            177268 ns/op
-BenchmarkClientServerRoundTripBigMapBigStrMsg-12            2766            436754 ns/op
----
-BenchmarkClientServerRoundTripSmallMsg-12                   9987            125366 ns/op
-BenchmarkClientServerRoundTripBigStrMsg-12                  7414            210762 ns/op
-BenchmarkClientServerRoundTripBigMapBigStrMsg-12            2172            465756 ns/op
 
 

--- a/bench/clientserver_roundtrip_test.go
+++ b/bench/clientserver_roundtrip_test.go
@@ -1,10 +1,12 @@
 package bench
 
 import (
+	"context"
 	"log"
 	"os"
 	"testing"
 	"time"
+	// "github.com/gogo/protobuf/proto"
 )
 
 // go test -run=^BenchmarkClientServerRoundTrip -bench=. -benchmem
@@ -41,8 +43,12 @@ func BenchmarkClientServerRoundTripBigMapBigStrMsg(b *testing.B) {
 }
 
 func benchRunner(b *testing.B, logger *log.Logger, evtMsg *Event) {
+	// ops := grid.OptionalParm{proto.NewBuffer(make([]byte, 1024))}
+	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
-		response, err := client.Request(10*time.Second, mailboxName, evtMsg)
+		timeoutC, cancel := context.WithTimeout(ctx, 10*time.Second)
+		response, err := client.RequestC(timeoutC, mailboxName, evtMsg)
+		cancel()
 		successOrDie(logger, err)
 		switch response.(type) {
 		case *EventResponse:

--- a/bench/clientserver_roundtrip_test.go
+++ b/bench/clientserver_roundtrip_test.go
@@ -43,7 +43,6 @@ func BenchmarkClientServerRoundTripBigMapBigStrMsg(b *testing.B) {
 }
 
 func benchRunner(b *testing.B, logger *log.Logger, evtMsg *Event) {
-	// ops := grid.OptionalParm{proto.NewBuffer(make([]byte, 1024))}
 	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
 		timeoutC, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/bench/clientserver_roundtrip_test.go
+++ b/bench/clientserver_roundtrip_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 	"time"
-	// "github.com/gogo/protobuf/proto"
 )
 
 // go test -run=^BenchmarkClientServerRoundTrip -bench=. -benchmem

--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	// "github.com/gogo/protobuf/proto"
 	"github.com/lytics/grid/codec"
 	"github.com/lytics/grid/registry"
@@ -142,24 +141,20 @@ func (c *Client) Close() error {
 	return err
 }
 
-type OptionalParm struct {
-	Buffer *proto.Buffer
-}
-
 // Request a response for the given message.
-func (c *Client) Request(timeout time.Duration, receiver string, msg interface{}, opts ...OptionalParm) (interface{}, error) {
+func (c *Client) Request(timeout time.Duration, receiver string, msg interface{}) (interface{}, error) {
 	if c == nil {
 		return nil, ErrNilClient
 	}
 
 	timeoutC, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	return c.RequestC(timeoutC, receiver, msg, opts...)
+	return c.RequestC(timeoutC, receiver, msg)
 }
 
 // RequestC (request) a response for the given message. The context can be
 // used to control cancelation or timeouts.
-func (c *Client) RequestC(ctx context.Context, receiver string, msg interface{}, opts ...OptionalParm) (interface{}, error) {
+func (c *Client) RequestC(ctx context.Context, receiver string, msg interface{}) (interface{}, error) {
 	if c == nil {
 		return nil, ErrNilClient
 	}
@@ -170,14 +165,7 @@ func (c *Client) RequestC(ctx context.Context, receiver string, msg interface{},
 		return nil, err
 	}
 
-	var typeName string
-	var data []byte
-	if len(opts) > 0 && opts[0].Buffer != nil {
-		var buff *proto.Buffer = opts[0].Buffer
-		typeName, data, err = codec.MarshalWithBuffer(msg, buff)
-	} else {
-		typeName, data, err = codec.Marshal(msg)
-	}
+	typeName, data, err := codec.Marshal(msg)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	// "github.com/gogo/protobuf/proto"
 	"github.com/lytics/grid/codec"
 	"github.com/lytics/grid/registry"
 	"github.com/lytics/retry"

--- a/codec/registry.go
+++ b/codec/registry.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
+	// "github.com/gogo/protobuf/proto"
 )
 
 var (
@@ -55,7 +56,27 @@ func Marshal(v interface{}) (string, []byte, error) {
 	if !ok {
 		return "", nil, ErrUnregisteredMessageType
 	}
+
+	// buff, release := getProtoBuffer()
+	// defer release()
+	// buf, err := protoMarshalBuffer(v, buff)
 	buf, err := protoMarshal(v)
+	if err != nil {
+		return "", nil, err
+	}
+	return name, buf, nil
+}
+
+func MarshalWithBuffer(v interface{}, buff *proto.Buffer) (string, []byte, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	name := TypeName(v)
+	_, ok := registry[name]
+	if !ok {
+		return "", nil, ErrUnregisteredMessageType
+	}
+	buf, err := protoMarshalBuffer(v, buff)
 	if err != nil {
 		return "", nil, err
 	}
@@ -99,7 +120,32 @@ func protoMarshal(v interface{}) ([]byte, error) {
 	return proto.Marshal(pb)
 }
 
+func protoMarshalBuffer(v interface{}, buff *proto.Buffer) ([]byte, error) {
+	pb := v.(proto.Message)
+	buff.Reset()
+	if err := buff.Marshal(pb); err != nil {
+		return nil, err
+	}
+	return buff.Bytes(), nil
+}
+
 func protoUnmarshal(buf []byte, v interface{}) error {
 	pb := v.(proto.Message)
 	return proto.Unmarshal(buf, pb)
 }
+
+// var protoBufferPool = sync.Pool{
+// 	New: func() interface{} {
+// 		return &proto.Buffer{}
+// 	},
+// }
+//
+// func getProtoBuffer() (*proto.Buffer, func()) {
+// 	bufI := protoBufferPool.Get()
+// 	buf := bufI.(*proto.Buffer)
+// 	releaser := func() {
+// 		// buf.Reset()
+// 		protoBufferPool.Put(buf)
+// 	}
+// 	return buf, releaser
+// }

--- a/codec/registry.go
+++ b/codec/registry.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
-	// "github.com/gogo/protobuf/proto"
 )
 
 var (
@@ -104,25 +103,4 @@ func protoMarshal(v interface{}) ([]byte, error) {
 func protoUnmarshal(buf []byte, v interface{}) error {
 	pb := v.(proto.Message)
 	return proto.Unmarshal(buf, pb)
-}
-
-// Example usage
-// buff, release := getProtoBuffer()
-// defer release()
-// buf, err := protoMarshalBuffer(v, buff)
-
-var protoBufferPool = sync.Pool{
-	New: func() interface{} {
-		return &proto.Buffer{}
-	},
-}
-
-func getProtoBuffer() (*proto.Buffer, func()) {
-	bufI := protoBufferPool.Get()
-	buf := bufI.(*proto.Buffer)
-	releaser := func() {
-		// buf.Reset()
-		protoBufferPool.Put(buf)
-	}
-	return buf, releaser
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
-	github.com/gogo/protobuf v1.3.0 // indirect
+	github.com/gogo/protobuf v1.3.0
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/google/go-cmp v0.3.1 // indirect

--- a/mailbox.go
+++ b/mailbox.go
@@ -100,12 +100,15 @@ func NewMailbox(s *Server, name string, size int) (*Mailbox, error) {
 }
 
 func newMailbox(s *Server, name, nsName string, size int) (*Mailbox, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mumb.Lock()
+	defer s.mumb.Unlock()
 
+	s.mu.Lock()
 	if s.mailboxes == nil {
+		s.mu.Unlock()
 		return nil, ErrServerNotRunning
 	}
+	s.mu.Unlock()
 
 	_, ok := s.mailboxes[nsName]
 	if ok {
@@ -133,8 +136,8 @@ func newMailbox(s *Server, name, nsName string, size int) (*Mailbox, error) {
 
 	boxC := make(chan Request, size)
 	cleanup := func() error {
-		s.mu.Lock()
-		defer s.mu.Unlock()
+		s.mumb.Lock()
+		defer s.mumb.Unlock()
 
 		// Immediately delete the subscription so that no one
 		// can send to it, at least from this host.

--- a/mailbox.go
+++ b/mailbox.go
@@ -100,15 +100,15 @@ func NewMailbox(s *Server, name string, size int) (*Mailbox, error) {
 }
 
 func newMailbox(s *Server, name, nsName string, size int) (*Mailbox, error) {
-	s.mumb.Lock()
-	defer s.mumb.Unlock()
-
 	s.mu.Lock()
 	if s.mailboxes == nil {
 		s.mu.Unlock()
 		return nil, ErrServerNotRunning
 	}
 	s.mu.Unlock()
+
+	s.mumb.Lock()
+	defer s.mumb.Unlock()
 
 	_, ok := s.mailboxes[nsName]
 	if ok {

--- a/server.go
+++ b/server.go
@@ -143,7 +143,7 @@ func (s *Server) Serve(lis net.Listener) error {
 
 	// Create the mailboxes map.
 	s.mu.Lock()
-	// no need to take the s.mumb Lock here, since no mailbox ops should occur before a call to Serve.  I hope.
+	// no need to take the s.mumb Lock here, since no mailbox ops should occur before a call to Serve.  
 	s.mailboxes = make(map[string]*Mailbox)
 	s.mu.Unlock()
 

--- a/server.go
+++ b/server.go
@@ -29,7 +29,9 @@ type contextVal struct {
 
 // Server of a grid.
 type Server struct {
-	mu        sync.Mutex
+	mu   sync.Mutex
+	mumb sync.RWMutex // Mutext used to sync mailboxes map
+
 	ctx       context.Context
 	cancel    func()
 	cfg       ServerCfg
@@ -141,6 +143,7 @@ func (s *Server) Serve(lis net.Listener) error {
 
 	// Create the mailboxes map.
 	s.mu.Lock()
+	// no need to take the s.mumb Lock here, since no mailbox ops should occur before a call to Serve.  I hope.
 	s.mailboxes = make(map[string]*Mailbox)
 	s.mu.Unlock()
 
@@ -181,16 +184,16 @@ func (s *Server) Serve(lis net.Listener) error {
 // this server have called their close method.
 func (s *Server) Stop() {
 	logMailboxes := func() {
-		s.mu.Lock()
-		defer s.mu.Unlock()
+		s.mumb.RLock()
+		defer s.mumb.RUnlock()
 		for _, mailbox := range s.mailboxes {
 			s.logf("%v: waiting for mailbox to close: %v", s.cfg.Namespace, mailbox)
 		}
 	}
 
 	zeroMailboxes := func() bool {
-		s.mu.Lock()
-		defer s.mu.Unlock()
+		s.mumb.RLock()
+		defer s.mumb.RUnlock()
 		return len(s.mailboxes) == 0
 	}
 
@@ -221,8 +224,8 @@ func (s *Server) Stop() {
 // gRPC definition of the wire service. Consider this a private method.
 func (s *Server) Process(c netcontext.Context, d *Delivery) (*Delivery, error) {
 	getMailbox := func() (*Mailbox, bool) {
-		s.mu.Lock()
-		defer s.mu.Unlock()
+		s.mumb.RLock()
+		defer s.mumb.RUnlock()
 		m, ok := s.mailboxes[d.Receiver]
 		return m, ok
 	}


### PR DESCRIPTION
- Reducing the number of allocations per operation by PreCompiling the names regex and reusing it, vs recompiling it multiple times per message.
- Adding finer grain lock control in the server.  So that Locking to create an actor doesn't stop all message processing because the server can't acquire a mailbox when receiving a new gRPC message. 