### PR TITLE
adding a wait for previous leases to expire if they don't exist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.x.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -180,7 +180,7 @@ func (rr *Registry) Start(addr net.Addr) error {
 
 	// Ensure that we're the owner of the address by taking an etcd lock
 	timeout, cancel = context.WithTimeout(context.Background(), rr.Timeout)
-	rr.waitForAddress(timeout, address)
+	err = rr.waitForAddress(timeout, address)
 	cancel()
 	if err != nil {
 		return err

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lytics/retry"
 	etcdv3 "go.etcd.io/etcd/clientv3"
 )
 
@@ -34,6 +35,7 @@ var (
 	ErrWatchClosedUnexpectedly     = errors.New("registry: watch closed unexpectedly")
 	ErrUnspecifiedNetAddressIP     = errors.New("registry: unspecified net address ip")
 	ErrKeepAliveClosedUnexpectedly = errors.New("registry: keep alive closed unexpectedly")
+	ErrFailedAcquireAddressLock    = errors.New("registry: address lock exists after timeout")
 )
 
 var (
@@ -122,32 +124,52 @@ func New(client *etcdv3.Client) (*Registry, error) {
 	}, nil
 }
 
+func registryLockKey(address string) string {
+	return fmt.Sprintf("%v.%v", "registry.uniq-lock", address)
+}
+
 func (rr *Registry) waitForAddress(ctx context.Context, address string) error {
-	key := fmt.Sprintf("%v.%v", "registry.uniq-lock", address)
+	key := registryLockKey(address)
 
-	res, err := rr.kv.Get(ctx, key, etcdv3.WithLimit(1))
-	if err != nil {
-		return fmt.Errorf("waitForAddress failed to get address lock: error: %w", err)
-	}
-	if res.Count != 0 {
+	const infiniteRetries = 10000
+	var locked bool = true
+	var rErr error
+	retry.X(infiniteRetries, time.Second, func() bool {
 		select {
-		case <-time.After(rr.LeaseDuration):
 		case <-ctx.Done():
-			return nil
+			// we timed out waiting for it to expire
+			return false
+		default:
 		}
+
+		res, err := rr.kv.Get(ctx, key, etcdv3.WithLimit(1))
+		if err != nil {
+			// don't retry on an error to etcd, just expect the process/pod to restart
+			rErr = err
+			return false
+		}
+		if res.Count != 0 {
+			// the lock is being held by someone
+			return true
+		}
+		// the lock is cleared
+		locked = false
+		return false
+	})
+
+	if rErr != nil && rErr != context.Canceled {
+		return fmt.Errorf("registry: failed get address lock: error: %w", rErr)
 	}
 
-	res, err = rr.kv.Get(ctx, key, etcdv3.WithLimit(1))
-	if err != nil {
-		return fmt.Errorf("waitForAddress failed to get address lock: error: %w", err)
-	}
-	if res.Count != 0 {
-		return fmt.Errorf("waitForAddress lease exists after timeout")
+	if locked {
+		return ErrFailedAcquireAddressLock
 	}
 
-	_, err = rr.kv.Put(ctx, key, "", etcdv3.WithLease(rr.leaseID))
+	tctx, cancel := context.WithTimeout(ctx, rr.Timeout)
+	_, err := rr.kv.Put(tctx, key, "", etcdv3.WithLease(rr.leaseID))
+	cancel()
 	if err != nil {
-		return fmt.Errorf("waitForAddress failed to write address lock: error: %w", err)
+		return fmt.Errorf("registry: failed to write address lock: error: %w", err)
 	}
 
 	return nil
@@ -179,9 +201,8 @@ func (rr *Registry) Start(addr net.Addr) error {
 	rr.leaseID = res.ID
 
 	// Ensure that we're the owner of the address by taking an etcd lock
-	timeout, cancel = context.WithTimeout(context.Background(), rr.Timeout)
-	err = rr.waitForAddress(timeout, address)
-	cancel()
+	tctx, cancel := context.WithTimeout(context.TODO(), rr.LeaseDuration*2) // retry until Lease is up...
+	err = rr.waitForAddress(tctx, address)
 	if err != nil {
 		return err
 	}

--- a/testetcd/etcdserver.go
+++ b/testetcd/etcdserver.go
@@ -49,7 +49,7 @@ func NewEmbedded() *Embedded {
 
 	select {
 	case <-e.Server.ReadyNotify():
-		fmt.Printf("Started embedded etcd on url: %v", clientURL)
+		fmt.Printf("Started embedded etcd on url: %v\n", clientURL)
 
 	case <-time.After(10 * time.Second):
 		e.Server.Stop() // trigger a shutdown


### PR DESCRIPTION
An update to how a grid server starts up so that it waits for previous leases to the same address to be freed before startup.  Currently, our grid services have to wait for the lease-timeout before the restart, incase the restart was from a panic.  The is to avoid registering actors that we no longer own.   The downside of this approach is that during deploys or auto-scaling events, we're waiting two minutes before starting any work.

After this change, we'll start up without waiting during autoscaling or deploys.  And will only have to wait around for the lease to expire after a panic recovery. 