### PR TITLE
Return the DeadlineExceeded error

### DIFF
--- a/server.go
+++ b/server.go
@@ -435,6 +435,7 @@ func (s *Server) startActorC(c context.Context, start *ActorStart) error {
 	case err == nil:
 	case errors.Is(err, context.DeadlineExceeded), status.Code(err) == codes.DeadlineExceeded:
 		s.deregisterActor(nsName)
+		return fmt.Errorf("registering actor %q: %w", nsName, err)
 	default:
 		return fmt.Errorf("registering actor %q: %w", nsName, err)
 	}


### PR DESCRIPTION
Ticket: lytics/lio#24378

We were erroneously continuing if we failed to registered the actor. This would lead to a second actor being started 🤦🏻‍♂️. The second actor would fail to create a mailbox, die, unregister itself, and continue doing that ad infinitum.